### PR TITLE
feat: expand doctor ai readiness checks

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -391,7 +391,7 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
         lines.append("WARN no [tool.vex.scripts] aliases configured")
 
     if scope == "ai":
-        for script_name in ("dev", "benchmark"):
+        for script_name in ("dev", "benchmark", "eval"):
             if script_name in scripts:
                 lines.append(f"OK  found AI workflow script '{script_name}'")
             else:
@@ -404,6 +404,36 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
         else:
             issues += 1
             lines.append("WARN missing [tool.vex.policy] configuration")
+
+        deploy_targets_path = root / "deploy.targets.toml"
+        deploy_config = load_deploy_targets(root)
+        profiles = deploy_config.get("profiles", {}) if isinstance(deploy_config, dict) else {}
+        if deploy_targets_path.exists() and isinstance(profiles, dict) and "default" in profiles:
+            lines.append("OK  found deploy.targets.toml with default profile")
+        else:
+            issues += 1
+            lines.append("WARN missing deploy.targets.toml default profile")
+
+        runtime_root = resolve_runtime_root(root)
+        if runtime_root is not None:
+            lines.append(f"OK  runtime path resolved to {runtime_root}")
+            schema_path = runtime_root / "schemas" / "vex-model-schema.json"
+            if schema_path.exists():
+                lines.append("OK  found shared model schema in runtime")
+            else:
+                issues += 1
+                lines.append("WARN runtime schema file missing")
+        else:
+            issues += 1
+            lines.append("WARN runtime path not resolved (set VEX_AI_RUNTIME_PATH if needed)")
+
+        if bool(policy.get("sandbox", True)):
+            backend = sandbox_backend(policy)
+            if backend == "none":
+                issues += 1
+                lines.append("WARN no sandbox backend detected (install docker or podman)")
+            else:
+                lines.append(f"OK  sandbox backend detected: {backend}")
 
         drift = schema_drift_warning(root)
         if drift:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -300,7 +300,56 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(code, 1)
         self.assertIn("WARN missing AI workflow script 'dev'", output)
+        self.assertIn("WARN missing AI workflow script 'eval'", output)
         self.assertIn("WARN missing [tool.vex.policy] configuration", output)
+
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_reports_healthy_setup(self, _uv_bin: object, _sandbox_backend: object) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "engine" / "vex-ai-runtime"
+            (runtime_root / "schemas").mkdir(parents=True)
+            (runtime_root / "schemas" / "vex-model-schema.json").write_text(
+                '{"schema":"vex-model/v1","schema_version":"v1","runtime":"vex-ai-runtime","engine":"onnxruntime"}\n',
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.env]\npath = \".venv\"\n\n"
+                "[tool.vex.scripts]\n"
+                'dev = "python -m demo.main"\n'
+                'benchmark = "python -m demo.benchmark"\n'
+                'eval = "python evals/run_eval.py --input {input}"\n'
+                'test = "pytest"\n\n'
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'network = "deny"\n',
+                encoding="utf-8",
+            )
+            (root / "deploy.targets.toml").write_text(
+                "[profiles.default]\n"
+                'image = "ghcr.io/example/demo"\n',
+                encoding="utf-8",
+            )
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            (root / ".venv").mkdir()
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        self.assertIn("OK  found AI workflow script 'dev'", output)
+        self.assertIn("OK  found AI workflow script 'benchmark'", output)
+        self.assertIn("OK  found AI workflow script 'eval'", output)
+        self.assertIn("OK  found deploy.targets.toml with default profile", output)
+        self.assertIn("OK  runtime path resolved to", output)
+        self.assertIn("OK  found shared model schema in runtime", output)
+        self.assertIn("OK  sandbox backend detected: docker", output)
 
     def test_policy_prints_config(self) -> None:
         original_cwd = os.getcwd()


### PR DESCRIPTION
## Summary
- extend `vex doctor ai` with checks for eval script, deploy profile defaults, runtime schema availability, and sandbox backend readiness
- surface clearer warnings when runtime path or sandbox backend is missing
- add coverage for healthy AI setup and expanded warning paths

## Validation
- make test