### PR TITLE
feat: add deploy preflight check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Under the hood:
 - `vex package-model <model.onnx> [--skip-compat-check]`
 - `vex deploy docker|cloud-run|modal` (with `--apply` / `--run` on supported targets)
 - `vex deploy --profile <name>` to load defaults from `deploy.targets.toml`
+- `vex deploy check [--for all|docker|cloud-run|modal]` for deployment preflight
 - deploy profiles support inheritance (`inherit = "default"`) and env interpolation (for example `${VEX_IMAGE_REPO}`)
 - `vex schema validate-model [artifact_dir]`
 
@@ -133,6 +134,7 @@ PYTHONPATH=src python3 -m vex policy set network allow --type str
 PYTHONPATH=src python3 -m vex policy get network
 PYTHONPATH=src python3 -m vex package-model path/to/model.onnx --out-dir dist/model
 PYTHONPATH=src python3 -m vex schema validate-model dist/model
+PYTHONPATH=src python3 -m vex deploy check --for all
 PYTHONPATH=src python3 -m vex deploy cloud-run --service demo-service --apply
 PYTHONPATH=src python3 -m vex deploy modal --app-name demo-app --run
 PYTHONPATH=src python3 -m vex doctor

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,7 @@ These commands are useful bootstrap plumbing because they let `vex` ride on top 
 - `vex policy`
 - `vex package-model`
 - `vex deploy`
+- `vex deploy check`
 - `vex schema validate-model`
 - `vex run --sandbox`
 - `vex doctor ai`

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -1221,6 +1221,88 @@ def scaffold_modal(root: Path, app_name: str) -> Path:
     return path
 
 
+def detect_gcloud_project() -> str | None:
+    if shutil.which("gcloud") is None:
+        return None
+    code, stdout, _stderr = run_command_capture(["gcloud", "config", "get-value", "project"]) 
+    if code != 0:
+        return None
+    value = stdout.strip()
+    if not value or value == "(unset)":
+        return None
+    return value
+
+
+def deploy_preflight(root: Path, target: str, profile: dict[str, Any]) -> tuple[int, list[str]]:
+    issues = 0
+    lines: list[str] = []
+
+    if uv_bin():
+        lines.append("OK  uv available")
+    else:
+        issues += 1
+        lines.append("WARN uv not found on PATH")
+
+    image = str(profile.get("image", "vex-app"))
+    tag = str(profile.get("tag", "latest"))
+    lines.append(f"OK  profile image={image}:{tag}")
+
+    targets = [target]
+    if target == "all":
+        targets = ["docker", "cloud-run", "modal"]
+
+    for item in targets:
+        if item == "docker":
+            tool = docker_like_bin()
+            if tool:
+                lines.append(f"OK  docker-compatible CLI found: {tool}")
+            else:
+                issues += 1
+                lines.append("WARN docker/podman not found")
+
+        if item == "cloud-run":
+            if shutil.which("gcloud"):
+                lines.append("OK  gcloud CLI found")
+            else:
+                issues += 1
+                lines.append("WARN gcloud CLI not found")
+
+            project = os.environ.get("GOOGLE_CLOUD_PROJECT") or detect_gcloud_project()
+            if project:
+                lines.append(f"OK  Google Cloud project configured: {project}")
+            else:
+                issues += 1
+                lines.append("WARN Google Cloud project not configured")
+
+        if item == "modal":
+            if shutil.which("modal"):
+                lines.append("OK  modal CLI found")
+            else:
+                issues += 1
+                lines.append("WARN modal CLI not found")
+
+            token_id = os.environ.get("MODAL_TOKEN_ID")
+            token_secret = os.environ.get("MODAL_TOKEN_SECRET")
+            if token_id and token_secret:
+                lines.append("OK  Modal token env vars present")
+            else:
+                lines.append("WARN Modal token env vars missing (MODAL_TOKEN_ID/MODAL_TOKEN_SECRET)")
+
+    runtime_root = resolve_runtime_root(root)
+    if runtime_root is not None:
+        lines.append(f"OK  runtime root detected: {runtime_root}")
+    else:
+        lines.append("WARN runtime root not detected; set VEX_AI_RUNTIME_PATH if needed")
+
+    deploy_targets = root / "deploy.targets.toml"
+    if deploy_targets.exists():
+        lines.append("OK  deploy.targets.toml present")
+    else:
+        lines.append("WARN deploy.targets.toml not found")
+
+    return issues, lines
+
+
 def runtime_compatibility_check(root: Path, artifact_dir: Path) -> tuple[bool, str]:
     runtime_root = resolve_runtime_root(root)
     if runtime_root is None:
@@ -1318,7 +1400,7 @@ def build_parser() -> argparse.ArgumentParser:
     eval_parser.set_defaults(handler=handle_eval)
 
     deploy_parser = subparsers.add_parser("deploy", help=COMMAND_HELP["deploy"])
-    deploy_parser.add_argument("target", choices=["docker", "cloud-run", "modal"])
+    deploy_parser.add_argument("target", choices=["docker", "cloud-run", "modal", "check"])
     deploy_parser.add_argument("--image", default="vex-app")
     deploy_parser.add_argument("--tag", default="latest")
     deploy_parser.add_argument("--push", action="store_true")
@@ -1328,6 +1410,7 @@ def build_parser() -> argparse.ArgumentParser:
     deploy_parser.add_argument("--apply", action="store_true")
     deploy_parser.add_argument("--run", action="store_true")
     deploy_parser.add_argument("--profile", default="default")
+    deploy_parser.add_argument("--for", dest="check_target", choices=["all", "docker", "cloud-run", "modal"], default="all")
     deploy_parser.set_defaults(handler=handle_deploy)
 
     policy_parser = subparsers.add_parser("policy", help=COMMAND_HELP["policy"])
@@ -1628,6 +1711,12 @@ def handle_deploy(args: argparse.Namespace) -> int:
     region = str(profile.get("region", args.region))
     app_name = str(profile.get("app_name", args.app_name))
     push = bool(profile.get("push", args.push))
+
+    if args.target == "check":
+        issues, lines = deploy_preflight(root, target=args.check_target, profile=profile)
+        for line in lines:
+            print(line)
+        return 0 if issues == 0 else 1
 
     if args.target == "docker":
         return deploy_docker(root, image=image, tag=tag, push=push)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -719,6 +719,42 @@ class CliTests(unittest.TestCase):
         self.assertIn("Wrote Cloud Run scaffold", output)
         self.assertIn("name: demo-svc", content)
 
+    @patch("vex.cli.detect_gcloud_project", return_value="demo-project")
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    @patch("vex.cli.shutil.which")
+    def test_deploy_check_reports_ready_state(
+        self,
+        which_mock: object,
+        _uv_bin: object,
+        _docker: object,
+        _project: object,
+    ) -> None:
+        which_mock.side_effect = lambda name: "/usr/bin/tool" if name in {"gcloud", "modal"} else None
+        code, output = self.run_cli(["deploy", "check"])
+        self.assertEqual(code, 0)
+        self.assertIn("OK  uv available", output)
+        self.assertIn("OK  docker-compatible CLI found: docker", output)
+        self.assertIn("OK  gcloud CLI found", output)
+        self.assertIn("OK  modal CLI found", output)
+
+    @patch("vex.cli.detect_gcloud_project", return_value=None)
+    @patch("vex.cli.docker_like_bin", return_value=None)
+    @patch("vex.cli.uv_bin", return_value=None)
+    @patch("vex.cli.shutil.which", return_value=None)
+    def test_deploy_check_reports_missing_tools(
+        self,
+        _which: object,
+        _uv_bin: object,
+        _docker: object,
+        _project: object,
+    ) -> None:
+        code, output = self.run_cli(["deploy", "check"])
+        self.assertEqual(code, 1)
+        self.assertIn("WARN uv not found", output)
+        self.assertIn("WARN docker/podman not found", output)
+        self.assertIn("WARN gcloud CLI not found", output)
+
     @patch("vex.cli.run_command", return_value=0)
     @patch("vex.cli.shutil.which", return_value="/usr/bin/gcloud")
     def test_deploy_cloud_run_apply_invokes_gcloud(self, _which: object, run_command: object) -> None:


### PR DESCRIPTION
## Summary
- add `vex deploy check` with target-specific preflight checks for docker, cloud-run, and modal
- include profile-aware diagnostics plus runtime/deploy config readiness signals
- expand `doctor ai` checks for eval scripts, deploy profiles, runtime schema, and sandbox backend

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests
- make test-runtime