### PR TITLE
fix: preserve single-arg shell string in vex run --sandbox

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -889,6 +889,8 @@ def resolve_run_shell_command(args: argparse.Namespace, root: Path) -> str | Non
     scripts = load_vex_scripts(root)
     script = scripts.get(args.args[0])
     if script is None:
+        if len(args.args) == 1:
+            return args.args[0]
         return " ".join(shlex.quote(value) for value in args.args)
     extra = " ".join(shlex.quote(value) for value in args.args[1:])
     return script if not extra else f"{script} {extra}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -418,6 +418,28 @@ class CliTests(unittest.TestCase):
         self.assertIn("unsafe local execution", output)
         run_command.assert_called_once_with(["sh", "-c", "echo hello"], cwd=root.resolve())
 
+    @patch("vex.cli.run_command", return_value=0)
+    def test_run_sandbox_preserves_single_quoted_shell_string(self, run_command: object) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                "unsafe_fallback = true\n"
+                'sandbox_backend = "none"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(["run", "--sandbox", "echo hi"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        run_command.assert_called_once_with(["sh", "-c", "echo hi"], cwd=root.resolve())
+
     def test_package_model_writes_manifest(self) -> None:
         original_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- `resolve_run_shell_command` unconditionally ran `shlex.quote` on every argv token, so a single-argv shell string like `"echo hi"` became `'echo hi'` inside `sh -c` and was treated as a command literally named `echo hi`.
- When exactly one argv token is supplied and it isn't a named script, pass it through verbatim as an already-formed shell string.
- Added regression test `test_run_sandbox_preserves_single_quoted_shell_string` covering the single-arg case.

Closes #4.

## Test plan
- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — 40/40 pass
- [x] `make test` — full monorepo suite green