### PR TITLE
feat: expand vex doctor ai with provider, dataset, image, and deploy env checks

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -434,12 +434,190 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
                 lines.append("WARN no sandbox backend detected (install docker or podman)")
             else:
                 lines.append(f"OK  sandbox backend detected: {backend}")
+                image = str(policy.get("sandbox_image", "python:3.12-slim"))
+                cached = sandbox_image_cached(backend, image)
+                if cached is True:
+                    lines.append(f"OK  sandbox image cached locally: {image}")
+                elif cached is False:
+                    lines.append(
+                        f"WARN sandbox image not cached locally: {image} "
+                        f"(run: {backend} pull {image})"
+                    )
+
+        issues += _append_ai_provider_checks(root, lines)
+        issues += _append_eval_dataset_checks(root, lines)
+        issues += _append_deploy_env_checks(root, lines)
 
         drift = schema_drift_warning(root)
         if drift:
             lines.append(drift)
 
     return issues, lines
+
+
+def sandbox_image_cached(backend: str, image: str) -> bool | None:
+    if backend not in {"docker", "podman"} or not shutil.which(backend):
+        return None
+    try:
+        result = subprocess.run(
+            [backend, "image", "inspect", image],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return result.returncode == 0
+
+
+_HOSTED_PROVIDER_KEYS: tuple[tuple[str, str], ...] = (
+    ("OPENAI_API_KEY", "openai"),
+    ("ANTHROPIC_API_KEY", "anthropic"),
+    ("GOOGLE_API_KEY", "google"),
+    ("GROQ_API_KEY", "groq"),
+)
+
+
+def _append_ai_provider_checks(root: Path, lines: list[str]) -> int:
+    issues = 0
+
+    found_keys = [(env, name) for env, name in _HOSTED_PROVIDER_KEYS if os.environ.get(env)]
+    for env, name in found_keys:
+        value = os.environ.get(env, "")
+        if env == "OPENAI_API_KEY" and value and not value.startswith(("sk-", "ollama")):
+            lines.append(f"WARN {env} set but does not start with 'sk-' (looks malformed)")
+            issues += 1
+        elif env == "ANTHROPIC_API_KEY" and value and not value.startswith("sk-ant-"):
+            lines.append(f"WARN {env} set but does not start with 'sk-ant-' (looks malformed)")
+            issues += 1
+        else:
+            lines.append(f"OK  hosted provider credential detected: {name} ({env})")
+
+    ollama_on_path = shutil.which("ollama") is not None
+    if not found_keys:
+        if ollama_on_path:
+            lines.append("OK  no hosted provider keys; ollama available on PATH (local fallback)")
+        else:
+            lines.append(
+                "WARN no hosted provider keys set and 'ollama' not on PATH "
+                "(install ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY)"
+            )
+            issues += 1
+    else:
+        if ollama_on_path:
+            lines.append("OK  ollama available on PATH (local fallback)")
+
+    env_example = root / ".env.example"
+    if env_example.exists():
+        declared: list[str] = []
+        for line in env_example.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if not stripped or "=" not in stripped:
+                continue
+            key = stripped.split("=", 1)[0].strip()
+            if key and key.isupper():
+                declared.append(key)
+        expected_provider_keys = [k for k in declared if k.endswith("_API_KEY")]
+        missing = [
+            k for k in expected_provider_keys
+            if not os.environ.get(k) and not any(k == env for env, _ in _HOSTED_PROVIDER_KEYS if os.environ.get(env))
+        ]
+        all_missing = all(not os.environ.get(k) for k in expected_provider_keys)
+        if expected_provider_keys and all_missing and not ollama_on_path:
+            lines.append(
+                f"WARN .env.example declares {len(expected_provider_keys)} provider key(s) "
+                f"but none are set in the environment"
+            )
+            issues += 1
+        elif expected_provider_keys and all_missing:
+            lines.append(
+                f"OK  .env.example declares {len(expected_provider_keys)} provider key(s); "
+                f"none set — will use ollama fallback"
+            )
+
+    return issues
+
+
+def _append_eval_dataset_checks(root: Path, lines: list[str]) -> int:
+    issues = 0
+    datasets_dir = root / "evals" / "datasets"
+    if not datasets_dir.exists():
+        return issues
+
+    dataset_files = sorted(p for p in datasets_dir.glob("*.jsonl") if p.is_file())
+    if not dataset_files:
+        lines.append("WARN evals/datasets/ present but no .jsonl datasets found")
+        return issues
+
+    for dataset in dataset_files:
+        rel = dataset.relative_to(root)
+        try:
+            raw_lines = dataset.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            lines.append(f"WARN could not read {rel}: {exc}")
+            issues += 1
+            continue
+
+        non_empty = [line for line in raw_lines if line.strip()]
+        if not non_empty:
+            lines.append(f"WARN {rel} has no cases")
+            issues += 1
+            continue
+
+        bad_rows = 0
+        missing_input = 0
+        for raw in non_empty:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                bad_rows += 1
+                continue
+            if not isinstance(parsed, dict) or "input" not in parsed:
+                missing_input += 1
+
+        if bad_rows or missing_input:
+            lines.append(
+                f"WARN {rel}: {len(non_empty)} rows, {bad_rows} invalid JSON, "
+                f"{missing_input} missing 'input' field"
+            )
+            issues += 1
+        else:
+            lines.append(f"OK  eval dataset {rel}: {len(non_empty)} cases valid")
+
+    return issues
+
+
+_ENV_INTERP_PATTERN = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
+
+
+def _append_deploy_env_checks(root: Path, lines: list[str]) -> int:
+    issues = 0
+    targets_path = root / "deploy.targets.toml"
+    if not targets_path.exists():
+        return issues
+
+    try:
+        raw = targets_path.read_text(encoding="utf-8")
+    except OSError:
+        return issues
+
+    referenced = sorted(set(_ENV_INTERP_PATTERN.findall(raw)))
+    if not referenced:
+        return issues
+
+    unbound = [name for name in referenced if not os.environ.get(name)]
+    if unbound:
+        lines.append(
+            f"WARN deploy.targets.toml references unbound env vars: {', '.join(unbound)}"
+        )
+        issues += 1
+    else:
+        lines.append(
+            f"OK  deploy.targets.toml env vars bound ({len(referenced)} referenced)"
+        )
+
+    return issues
 
 
 def default_package_name(root: Path, explicit_name: str | None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -303,9 +303,13 @@ class CliTests(unittest.TestCase):
         self.assertIn("WARN missing AI workflow script 'eval'", output)
         self.assertIn("WARN missing [tool.vex.policy] configuration", output)
 
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-testkey"}, clear=False)
+    @patch("vex.cli.sandbox_image_cached", return_value=True)
     @patch("vex.cli.sandbox_backend", return_value="docker")
     @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
-    def test_doctor_ai_reports_healthy_setup(self, _uv_bin: object, _sandbox_backend: object) -> None:
+    def test_doctor_ai_reports_healthy_setup(
+        self, _uv_bin: object, _sandbox_backend: object, _image_cached: object
+    ) -> None:
         original_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -350,6 +354,95 @@ class CliTests(unittest.TestCase):
         self.assertIn("OK  runtime path resolved to", output)
         self.assertIn("OK  found shared model schema in runtime", output)
         self.assertIn("OK  sandbox backend detected: docker", output)
+        self.assertIn("OK  sandbox image cached locally", output)
+        self.assertIn("OK  hosted provider credential detected: openai (OPENAI_API_KEY)", output)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.shutil.which", return_value=None)
+    @patch("vex.cli.sandbox_image_cached", return_value=None)
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_warns_when_no_provider_and_no_ollama(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+        _which: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn(
+            "WARN no hosted provider keys set and 'ollama' not on PATH",
+            output,
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.shutil.which", return_value=None)
+    @patch("vex.cli.sandbox_image_cached", return_value=None)
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_validates_eval_dataset_and_deploy_env(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+        _which: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            datasets_dir = root / "evals" / "datasets"
+            datasets_dir.mkdir(parents=True)
+            (datasets_dir / "good.jsonl").write_text(
+                '{"input": "a"}\n{"input": "b"}\n',
+                encoding="utf-8",
+            )
+            (datasets_dir / "broken.jsonl").write_text(
+                '{"input": "ok"}\n{not json\n{"no_input": true}\n',
+                encoding="utf-8",
+            )
+            (root / "deploy.targets.toml").write_text(
+                "[profiles.default]\n"
+                'image = "${VEX_IMAGE_REPO}/demo"\n'
+                'region = "${VEX_DEPLOY_REGION}"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("OK  eval dataset evals/datasets/good.jsonl: 2 cases valid", output)
+        self.assertIn("WARN evals/datasets/broken.jsonl", output)
+        self.assertIn("invalid JSON", output)
+        self.assertIn(
+            "WARN deploy.targets.toml references unbound env vars: "
+            "VEX_DEPLOY_REGION, VEX_IMAGE_REPO",
+            output,
+        )
 
     def test_policy_prints_config(self) -> None:
         original_cwd = os.getcwd()


### PR DESCRIPTION
## Summary
Four new readiness checks land inside the `ai` scope of `vex doctor`, closing the gap between "doctor is green" and "the AI stack actually works":

1. **Sandbox image cache** — when a sandbox backend is detected, probes `<backend> image inspect` against the configured `sandbox_image`. On a miss, surfaces the exact pull command (`docker pull python:3.12-slim`). 5s timeout so doctor stays fast.
2. **Hosted provider credentials** — looks for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY` in the environment; validates obvious prefixes (`sk-`, `sk-ant-`). Falls back to an "ollama on PATH" info line. If `.env.example` declares provider keys and none are set (and no ollama), raises an issue.
3. **Eval dataset shape** — walks `evals/datasets/*.jsonl`, parses each row as JSON, counts invalid rows and missing-`input` rows. Turns broken fixtures into a clear warning instead of a silent eval failure later.
4. **Deploy env interpolation** — scans `deploy.targets.toml` for `${VAR}` references and warns on any unbound env vars so profile-driven deploys don't fail at runtime on a missing `VEX_IMAGE_REPO`.

All new checks live inside the existing `if scope == "ai":` block so `vex doctor` (no subcommand) is unaffected.

Closes #11.

## Test plan
- [x] 41/41 pass on `PYTHONPATH=src python3 -m unittest tests.test_cli`
- [x] Existing `test_doctor_ai_reports_healthy_setup` now patches `OPENAI_API_KEY` and `sandbox_image_cached` so it stays deterministic in sandboxed CI environments without provider keys or Docker access
- [x] New `test_doctor_ai_warns_when_no_provider_and_no_ollama` asserts the provider fallback warning fires when both paths are absent
- [x] New `test_doctor_ai_validates_eval_dataset_and_deploy_env` covers both the valid dataset path, the invalid-JSON path, and the unbound env var path
- [x] Live `vex doctor ai` against this repo shows the three new OK/WARN lines and no regressions

## Follow-ups
- Once `vex init inference-api` gets the same realness treatment as `#7`, consider adding a typed API health check (FastAPI app importable + `/healthz` responds).
- Model reachability check (ping the resolved provider endpoint) deferred — adds a network call to doctor, probably belongs behind an opt-in flag.