### PR TITLE
feat: vex deploy modal|cloud-run|docker ship end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every verb is a thin wrapper. Escape hatches everywhere — if you want `uv run 
   { "schema_version": "v1", "runtime": "vex-ai-runtime",
     "engine": "onnxruntime", "model_path": "models/model.onnx" }
   ```
-- `vex deploy docker|cloud-run|modal [--apply|--run]` — scaffold + execute; profile inheritance (`inherit = "default"`) and env interpolation (`${VEX_IMAGE_REPO}`)
+- `vex deploy docker|cloud-run|modal [--apply|--run]` — scaffold + ship end-to-end; `docker --run` builds and runs locally, `cloud-run --apply` runs `gcloud builds submit` then `gcloud run deploy` and echoes the service URL, `modal --run` invokes `modal deploy` and surfaces the `*.modal.run` URL. Profile inheritance (`inherit = "default"`), env interpolation (`${VEX_IMAGE_REPO}`), and Cloud Run profile fields (`project`, `memory`, `cpu`, `min_instances`, `max_instances`, `service_account`, `allow_unauthenticated`). Preflight runs automatically on `--apply`/`--run` (override with `--skip-preflight`).
 - `vex deploy check [--for all|docker|cloud-run|modal]` — preflight
 - `vex schema validate-model [artifact_dir]` — verify a packaged artifact
 - `vex doctor ai` — 13-check readiness report
@@ -103,7 +103,6 @@ The roadmap ([`docs/roadmap.md`](docs/roadmap.md)) and product boundary ([`docs/
 
 - `vex dev` upgraded to a real dev loop: [`watchfiles`](https://watchfiles.helpmanual.io) hot reload + local ollama fallback + inline trace tail
 - `vex eval` adapters for promptfoo and deepeval, with `--json` CI output and pass-rate gates
-- `vex deploy modal|cloud-run` as full end-to-end deployments, not just scaffolding
 - `vex doctor ai` extended to verify ollama availability, model reachability, eval dataset shape, deploy profile env vars
 - More opinionated `examples/` tree with runnable agents, inference APIs, and local RAG
 

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -1480,7 +1480,14 @@ def docker_like_bin() -> str | None:
     return shutil.which("docker") or shutil.which("podman")
 
 
-def deploy_docker(root: Path, image: str, tag: str, push: bool) -> int:
+def deploy_docker(
+    root: Path,
+    image: str,
+    tag: str,
+    push: bool,
+    run_container: bool = False,
+    port: int | None = None,
+) -> int:
     tool = docker_like_bin()
     if tool is None:
         print("No docker-compatible CLI found (docker or podman)")
@@ -1492,8 +1499,179 @@ def deploy_docker(root: Path, image: str, tag: str, push: bool) -> int:
         return build_code
 
     if push:
-        return run_command([tool, "push", full_image], cwd=root)
+        push_code = run_command([tool, "push", full_image], cwd=root)
+        if push_code != 0:
+            return push_code
+        print(f"Pushed image {full_image}")
+
+    if run_container:
+        mapped_port = port if port is not None else 8000
+        port_mapping = f"{mapped_port}:{mapped_port}"
+        run_code = run_command(
+            [tool, "run", "--rm", "-p", port_mapping, full_image],
+            cwd=root,
+        )
+        if run_code != 0:
+            return run_code
+        print(f"Ran image {full_image} on port {mapped_port}")
+        return 0
+
     print(f"Built image {full_image}")
+    return 0
+
+
+def _stringify(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def profile_value(
+    profile: dict[str, Any],
+    *keys: str,
+    default: Any = None,
+) -> Any:
+    """Return the first matching key from the profile, supporting aliases."""
+    for key in keys:
+        if key in profile:
+            return profile[key]
+    return default
+
+
+def parse_modal_url(output: str) -> str | None:
+    """Extract a deployed URL from modal CLI output.
+
+    Modal prints lines like ``View app at https://example--demo-app.modal.run``
+    or ``✓ Created web endpoint => https://...modal.run``.
+    """
+    if not output:
+        return None
+    pattern = re.compile(r"https?://[^\s'\"<>]+\.modal\.run[^\s'\"<>]*")
+    match = pattern.search(output)
+    if match:
+        return match.group(0).rstrip(".,)")
+    return None
+
+
+def parse_cloud_run_url(output: str) -> str | None:
+    """Extract a deployed service URL from gcloud run deploy output."""
+    if not output:
+        return None
+    pattern = re.compile(r"https?://[A-Za-z0-9.\-]+\.run\.app[^\s'\"<>]*")
+    match = pattern.search(output)
+    if match:
+        return match.group(0).rstrip(".,)")
+    return None
+
+
+def deploy_modal(root: Path, scaffold_path: Path) -> int:
+    if shutil.which("modal") is None:
+        print("modal CLI not found", file=sys.stderr)
+        return 127
+    code, stdout, stderr = run_command_capture(
+        ["modal", "deploy", str(scaffold_path)],
+        cwd=root,
+    )
+    if stdout:
+        sys.stdout.write(stdout)
+        if not stdout.endswith("\n"):
+            sys.stdout.write("\n")
+    if stderr:
+        sys.stderr.write(stderr)
+        if not stderr.endswith("\n"):
+            sys.stderr.write("\n")
+    if code != 0:
+        print(f"modal deploy failed with exit code {code}", file=sys.stderr)
+        return code
+    combined = (stdout or "") + "\n" + (stderr or "")
+    url = parse_modal_url(combined)
+    if url:
+        print(f"Deployed: {url}")
+    else:
+        print("Deployed (no URL detected in modal output)")
+    return 0
+
+
+def deploy_cloud_run(
+    root: Path,
+    service: str,
+    region: str,
+    image: str,
+    tag: str,
+    project: str | None,
+    profile: dict[str, Any],
+) -> int:
+    if shutil.which("gcloud") is None:
+        print("gcloud CLI not found", file=sys.stderr)
+        return 127
+
+    full_image = f"{image}:{tag}"
+
+    build_argv = ["gcloud", "builds", "submit", "--tag", full_image]
+    if project:
+        build_argv.extend(["--project", project])
+    build_code = run_command(build_argv, cwd=root)
+    if build_code != 0:
+        print(f"gcloud builds submit failed with exit code {build_code}", file=sys.stderr)
+        return build_code
+
+    deploy_argv: list[str] = [
+        "gcloud",
+        "run",
+        "deploy",
+        service,
+        "--image",
+        full_image,
+        "--region",
+        region,
+        "--format",
+        "value(status.url)",
+        "--quiet",
+    ]
+    if project:
+        deploy_argv.extend(["--project", project])
+
+    memory = _stringify(profile_value(profile, "memory"))
+    if memory:
+        deploy_argv.extend(["--memory", memory])
+    cpu = _stringify(profile_value(profile, "cpu"))
+    if cpu:
+        deploy_argv.extend(["--cpu", cpu])
+    min_instances = _stringify(profile_value(profile, "min_instances", "min-instances"))
+    if min_instances:
+        deploy_argv.extend(["--min-instances", min_instances])
+    max_instances = _stringify(profile_value(profile, "max_instances", "max-instances"))
+    if max_instances:
+        deploy_argv.extend(["--max-instances", max_instances])
+    service_account = _stringify(
+        profile_value(profile, "service_account", "service-account")
+    )
+    if service_account:
+        deploy_argv.extend(["--service-account", service_account])
+    allow_unauthenticated = profile_value(profile, "allow_unauthenticated", "allow-unauthenticated")
+    if isinstance(allow_unauthenticated, bool):
+        deploy_argv.append("--allow-unauthenticated" if allow_unauthenticated else "--no-allow-unauthenticated")
+
+    code, stdout, stderr = run_command_capture(deploy_argv, cwd=root)
+    if stdout:
+        sys.stdout.write(stdout)
+        if not stdout.endswith("\n"):
+            sys.stdout.write("\n")
+    if stderr:
+        sys.stderr.write(stderr)
+        if not stderr.endswith("\n"):
+            sys.stderr.write("\n")
+    if code != 0:
+        print(f"gcloud run deploy failed with exit code {code}", file=sys.stderr)
+        return code
+
+    url = parse_cloud_run_url((stdout or "") + "\n" + (stderr or ""))
+    if url:
+        print(f"Deployed: {url}")
+    else:
+        print(f"Deployed service {service} (no URL detected in gcloud output)")
     return 0
 
 
@@ -1728,10 +1906,13 @@ def build_parser() -> argparse.ArgumentParser:
     deploy_parser.add_argument("--push", action="store_true")
     deploy_parser.add_argument("--service", default="vex-ai-service")
     deploy_parser.add_argument("--region", default="us-central1")
+    deploy_parser.add_argument("--project", default=None)
     deploy_parser.add_argument("--app-name", default="vex-ai-app")
     deploy_parser.add_argument("--apply", action="store_true")
     deploy_parser.add_argument("--run", action="store_true")
+    deploy_parser.add_argument("--port", type=int, default=None)
     deploy_parser.add_argument("--profile", default="default")
+    deploy_parser.add_argument("--skip-preflight", action="store_true")
     deploy_parser.add_argument("--for", dest="check_target", choices=["all", "docker", "cloud-run", "modal"], default="all")
     deploy_parser.set_defaults(handler=handle_deploy)
 
@@ -2022,17 +2203,47 @@ def handle_schema(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cli_value_is_explicit(args: argparse.Namespace, flag_name: str, default: Any) -> bool:
+    """Best-effort check: was a CLI flag explicitly set by the user?"""
+    value = getattr(args, flag_name, default)
+    return value != default
+
+
+def _resolve_setting(
+    args: argparse.Namespace,
+    profile: dict[str, Any],
+    cli_attr: str,
+    cli_default: Any,
+    *profile_keys: str,
+) -> Any:
+    """Profile precedence: CLI flag (if explicit) > profile value > CLI default."""
+    if _cli_value_is_explicit(args, cli_attr, cli_default):
+        return getattr(args, cli_attr)
+    for key in profile_keys:
+        if key in profile:
+            return profile[key]
+    return getattr(args, cli_attr, cli_default)
+
+
 def handle_deploy(args: argparse.Namespace) -> int:
     root = project_root()
     config = load_deploy_targets(root)
     profile = resolve_deploy_profile(config, args.profile)
 
-    image = str(profile.get("image", args.image))
-    tag = str(profile.get("tag", args.tag))
-    service = str(profile.get("service", args.service))
-    region = str(profile.get("region", args.region))
-    app_name = str(profile.get("app_name", args.app_name))
-    push = bool(profile.get("push", args.push))
+    image = str(_resolve_setting(args, profile, "image", "vex-app", "image"))
+    tag = str(_resolve_setting(args, profile, "tag", "latest", "tag"))
+    service = str(_resolve_setting(args, profile, "service", "vex-ai-service", "service"))
+    region = str(_resolve_setting(args, profile, "region", "us-central1", "region"))
+    app_name = str(
+        _resolve_setting(args, profile, "app_name", "vex-ai-app", "app_name", "app-name")
+    )
+    push = bool(_resolve_setting(args, profile, "push", False, "push"))
+
+    project_raw = _resolve_setting(args, profile, "project", None, "project")
+    project = str(project_raw) if project_raw else None
+
+    port_raw = _resolve_setting(args, profile, "port", None, "port")
+    port = int(port_raw) if port_raw is not None else None
 
     if args.target == "check":
         issues, lines = deploy_preflight(root, target=args.check_target, profile=profile)
@@ -2040,27 +2251,50 @@ def handle_deploy(args: argparse.Namespace) -> int:
             print(line)
         return 0 if issues == 0 else 1
 
+    # Run preflight when we're about to actually hit external systems.
+    if (args.apply or args.run) and not args.skip_preflight:
+        preflight_target = args.target if args.target in {"docker", "cloud-run", "modal"} else "all"
+        issues, lines = deploy_preflight(root, target=preflight_target, profile=profile)
+        for line in lines:
+            print(line)
+        if issues > 0:
+            print(
+                f"Preflight reported {issues} issue(s); aborting. "
+                "Re-run 'vex deploy check' or pass --skip-preflight to override.",
+                file=sys.stderr,
+            )
+            return 1
+
     if args.target == "docker":
-        return deploy_docker(root, image=image, tag=tag, push=push)
+        return deploy_docker(
+            root,
+            image=image,
+            tag=tag,
+            push=push,
+            run_container=bool(args.run),
+            port=port,
+        )
 
     if args.target == "cloud-run":
         path = scaffold_cloud_run(root, service=service, region=region, image=image, tag=tag)
         print(f"Wrote Cloud Run scaffold to {path}")
         if args.apply:
-            if shutil.which("gcloud") is None:
-                print("gcloud CLI not found")
-                return 127
-            return run_command(["gcloud", "run", "services", "replace", str(path), "--region", region], cwd=root)
+            return deploy_cloud_run(
+                root,
+                service=service,
+                region=region,
+                image=image,
+                tag=tag,
+                project=project,
+                profile=profile,
+            )
         return 0
 
     if args.target == "modal":
         path = scaffold_modal(root, app_name=app_name)
         print(f"Wrote Modal scaffold to {path}")
         if args.run:
-            if shutil.which("modal") is None:
-                print("modal CLI not found")
-                return 127
-            return run_command(["modal", "deploy", str(path)], cwd=root)
+            return deploy_modal(root, scaffold_path=path)
         return 0
 
     print("Unsupported deploy target")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -901,36 +901,253 @@ class CliTests(unittest.TestCase):
         self.assertIn("WARN docker/podman not found", output)
         self.assertIn("WARN gcloud CLI not found", output)
 
+    @patch("vex.cli.run_command_capture", return_value=(0, "https://svc-abcd-uw.a.run.app\n", ""))
     @patch("vex.cli.run_command", return_value=0)
+    @patch("vex.cli.detect_gcloud_project", return_value="demo-project")
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
     @patch("vex.cli.shutil.which", return_value="/usr/bin/gcloud")
-    def test_deploy_cloud_run_apply_invokes_gcloud(self, _which: object, run_command: object) -> None:
+    def test_deploy_cloud_run_apply_calls_gcloud_deploy(
+        self,
+        _which: object,
+        _uv_bin: object,
+        _docker: object,
+        _project: object,
+        run_command: object,
+        _run_capture: object,
+    ) -> None:
         original_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
             try:
-                code, _output = self.run_cli(["deploy", "cloud-run", "--apply", "--service", "svc", "--region", "us-west1"])
+                code, _output = self.run_cli(
+                    [
+                        "deploy",
+                        "cloud-run",
+                        "--apply",
+                        "--service",
+                        "svc",
+                        "--region",
+                        "us-west1",
+                        "--project",
+                        "demo-project",
+                        "--image",
+                        "gcr.io/demo-project/svc",
+                        "--tag",
+                        "v1",
+                    ]
+                )
             finally:
                 os.chdir(original_cwd)
 
         self.assertEqual(code, 0)
-        called_argv = run_command.call_args.args[0]
-        self.assertEqual(called_argv[0:4], ["gcloud", "run", "services", "replace"])
+        build_argv = run_command.call_args.args[0]
+        self.assertEqual(build_argv[0:3], ["gcloud", "builds", "submit"])
+        self.assertIn("gcr.io/demo-project/svc:v1", build_argv)
 
+        deploy_argv = _run_capture.call_args.args[0]
+        self.assertEqual(deploy_argv[0:4], ["gcloud", "run", "deploy", "svc"])
+        self.assertIn("--image", deploy_argv)
+        self.assertIn("gcr.io/demo-project/svc:v1", deploy_argv)
+        self.assertIn("--region", deploy_argv)
+        self.assertIn("us-west1", deploy_argv)
+        self.assertIn("--project", deploy_argv)
+        self.assertIn("demo-project", deploy_argv)
+
+    @patch("vex.cli.run_command_capture", return_value=(0, "https://svc.a.run.app\n", ""))
     @patch("vex.cli.run_command", return_value=0)
+    @patch("vex.cli.detect_gcloud_project", return_value="demo-project")
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    @patch("vex.cli.shutil.which", return_value="/usr/bin/gcloud")
+    def test_deploy_cloud_run_apply_respects_profile_interpolation(
+        self,
+        _which: object,
+        _uv_bin: object,
+        _docker: object,
+        _project: object,
+        run_command: object,
+        run_capture: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        previous_repo = os.environ.get("VEX_IMAGE_REPO")
+        os.environ["VEX_IMAGE_REPO"] = "gcr.io/demo"
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                (root / "deploy.targets.toml").write_text(
+                    "[profiles.default]\n"
+                    'image = "${VEX_IMAGE_REPO}/app"\n'
+                    'tag = "v7"\n'
+                    'service = "my-svc"\n'
+                    'region = "us-west1"\n'
+                    'project = "demo-project"\n'
+                    'memory = "1Gi"\n'
+                    'cpu = "2"\n'
+                    'min_instances = 1\n'
+                    'max_instances = 4\n'
+                    'service_account = "runner@demo-project.iam.gserviceaccount.com"\n',
+                    encoding="utf-8",
+                )
+                os.chdir(temp_dir)
+                try:
+                    code, _output = self.run_cli(["deploy", "cloud-run", "--apply"])
+                finally:
+                    os.chdir(original_cwd)
+        finally:
+            if previous_repo is None:
+                os.environ.pop("VEX_IMAGE_REPO", None)
+            else:
+                os.environ["VEX_IMAGE_REPO"] = previous_repo
+
+        self.assertEqual(code, 0)
+        build_argv = run_command.call_args.args[0]
+        self.assertIn("gcr.io/demo/app:v7", build_argv)
+
+        deploy_argv = run_capture.call_args.args[0]
+        self.assertIn("gcr.io/demo/app:v7", deploy_argv)
+        self.assertIn("--memory", deploy_argv)
+        self.assertIn("1Gi", deploy_argv)
+        self.assertIn("--cpu", deploy_argv)
+        self.assertIn("2", deploy_argv)
+        self.assertIn("--min-instances", deploy_argv)
+        self.assertIn("1", deploy_argv)
+        self.assertIn("--max-instances", deploy_argv)
+        self.assertIn("4", deploy_argv)
+        self.assertIn("--service-account", deploy_argv)
+        self.assertIn("runner@demo-project.iam.gserviceaccount.com", deploy_argv)
+
+    @patch("vex.cli.run_command_capture")
+    @patch("vex.cli.run_command")
+    @patch("vex.cli.deploy_preflight", return_value=(2, ["WARN missing tool"]))
+    def test_deploy_cloud_run_apply_runs_preflight_first(
+        self,
+        _preflight: object,
+        run_command: object,
+        run_capture: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    ["deploy", "cloud-run", "--apply", "--service", "svc", "--project", "p"]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("WARN missing tool", output)
+        run_command.assert_not_called()
+        run_capture.assert_not_called()
+
+    @patch(
+        "vex.cli.run_command_capture",
+        return_value=(
+            0,
+            "Building...\n✓ Created web endpoint => https://acme--demo-app.modal.run\n",
+            "",
+        ),
+    )
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
     @patch("vex.cli.shutil.which")
-    def test_deploy_modal_run_invokes_modal_cli(self, which_mock: object, run_command: object) -> None:
+    def test_deploy_modal_run_invokes_modal_cli(
+        self,
+        which_mock: object,
+        _uv_bin: object,
+        _docker: object,
+        run_capture: object,
+    ) -> None:
         which_mock.side_effect = lambda name: "/usr/bin/modal" if name == "modal" else None
         original_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
             try:
-                code, _output = self.run_cli(["deploy", "modal", "--run", "--app-name", "demo-app"])
+                code, _output = self.run_cli(
+                    [
+                        "deploy",
+                        "modal",
+                        "--run",
+                        "--app-name",
+                        "demo-app",
+                        "--skip-preflight",
+                    ]
+                )
             finally:
                 os.chdir(original_cwd)
 
         self.assertEqual(code, 0)
-        called_argv = run_command.call_args.args[0]
+        called_argv = run_capture.call_args.args[0]
         self.assertEqual(called_argv[0:2], ["modal", "deploy"])
+        # Scaffold path should be passed as third arg.
+        self.assertTrue(called_argv[2].endswith("modal_app.py"))
+
+    @patch(
+        "vex.cli.run_command_capture",
+        return_value=(
+            0,
+            "View app at https://acme--demo-app.modal.run\n",
+            "",
+        ),
+    )
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    @patch("vex.cli.shutil.which")
+    def test_deploy_modal_run_surfaces_deployed_url(
+        self,
+        which_mock: object,
+        _uv_bin: object,
+        _docker: object,
+        _run_capture: object,
+    ) -> None:
+        which_mock.side_effect = lambda name: "/usr/bin/modal" if name == "modal" else None
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "deploy",
+                        "modal",
+                        "--run",
+                        "--app-name",
+                        "demo-app",
+                        "--skip-preflight",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        self.assertIn("Deployed: https://acme--demo-app.modal.run", output)
+
+    @patch("vex.cli.docker_like_bin", return_value="docker")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_deploy_docker_run_builds_and_runs_image(
+        self, run_command: object, _docker: object
+    ) -> None:
+        code, _output = self.run_cli(
+            [
+                "deploy",
+                "docker",
+                "--image",
+                "ghcr.io/acme/app",
+                "--tag",
+                "v1",
+                "--run",
+                "--port",
+                "8080",
+                "--skip-preflight",
+            ]
+        )
+        self.assertEqual(code, 0)
+        argvs = [call.args[0] for call in run_command.call_args_list]
+        self.assertEqual(argvs[0], ["docker", "build", "-t", "ghcr.io/acme/app:v1", "."])
+        self.assertEqual(
+            argvs[-1],
+            ["docker", "run", "--rm", "-p", "8080:8080", "ghcr.io/acme/app:v1"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #10.

## Summary

Turn `vex deploy` from a scaffold-only command into a real ship-the-app flow. Before this PR, `cloud-run --apply` just ran `gcloud run services replace` against the yaml scaffold (no image build, no deploy URL surfaced) and `modal --run` shelled out to `modal deploy` without parsing any output. `docker --run` didn't actually run anything — only `docker build`. After this PR all three targets do the full round-trip through `run_command` / `run_command_capture` (so everything remains unit-testable).

## Behavior

### Modal — `vex deploy modal --run`
- **Before:** scaffold `modal_app.py`, shell out to `modal deploy`, swallow output.
- **After:** scaffold if missing, invoke `modal deploy` via `run_command_capture`, stream stdout/stderr verbatim, parse deployed URL from patterns like `View app at https://...modal.run` or `✓ Created web endpoint => https://...modal.run`, echo `Deployed: <url>` as the final line. Exit code is modal's real exit code on failure.

### Cloud Run — `vex deploy cloud-run --apply`
- **Before:** wrote `deploy/cloud-run.yaml`, ran `gcloud run services replace` against it.
- **After:** keeps the scaffold for reference, but also:
  1. `gcloud builds submit --tag <image>:<tag>` (honors `--project`).
  2. `gcloud run deploy <service> --image <image>:<tag> --region <region> --project <project> --format value(status.url)` with optional flags wired from profile: `--memory`, `--cpu`, `--min-instances`, `--max-instances`, `--service-account`, `--allow-unauthenticated` / `--no-allow-unauthenticated`.
  3. Captures service URL from the `status.url` output and echoes `Deployed: <url>` as the final line.

### Docker — `vex deploy docker --run`
- **Before:** `--run` was a no-op; `docker build` only.
- **After:** `docker build` then `docker run --rm -p <port>:<port> <image>:<tag>` using the new `--port` flag (default 8000). `--push` still works and is order-preserving (push before run when both are set).

### Preflight integration
Any invocation with `--apply` or `--run` now invokes the existing `deploy_preflight` first (scoped to the requested target: `docker` / `cloud-run` / `modal`). Non-zero issue count aborts before any subprocess is spawned. Escape hatch: `--skip-preflight` (useful in CI where the binaries are mocked). `vex deploy check` behavior is unchanged.

## Profile precedence

CLI flag (when explicitly passed) > active profile value > `default` profile value (via existing `inherit = "default"`) > env var (`${VAR}` interpolation, unchanged) > hardcoded CLI default.

Implemented in `_resolve_setting` / `_cli_value_is_explicit`. Reuses the existing `resolve_deploy_profile` and `interpolate_env_in_string` — no rewrite of profile loading.

### Newly-consumed profile fields (needs user review)

For `[profiles.<name>]` in `deploy.targets.toml`, Cloud Run now consumes:
- `project` — GCP project id
- `memory` — e.g. `"1Gi"`
- `cpu` — e.g. `"2"`
- `min_instances` / `min-instances`
- `max_instances` / `max-instances`
- `service_account` / `service-account`
- `allow_unauthenticated` (bool)

These are all optional; the scaffold template in `scaffold_deploy_targets` is not changed in this PR — existing generated `deploy.targets.toml` files keep working.

## New CLI flags

- `--project <gcp-project>` (cloud-run)
- `--port <int>` (docker --run, default 8000)
- `--skip-preflight`

## Constraints respected

- Every subprocess goes through `run_command` / `run_command_capture`.
- Exit codes propagate the real subprocess exit code on failure.
- No new deploy targets, no terraform/pulumi, no rewrite of profile loading.
- **No live-credential integration tests.** All new tests mock `run_command` / `run_command_capture` / `shutil.which`. A follow-up integration test pass that exercises real `modal deploy` / `gcloud run deploy` against sandbox projects is intentionally deferred.

## Tests added (all mocked, all passing)

- `test_deploy_modal_run_invokes_modal_cli` — asserts `modal deploy <scaffold-path>` is called.
- `test_deploy_modal_run_surfaces_deployed_url` — feeds `View app at https://...modal.run` into mocked stdout, asserts final `Deployed: <url>` line.
- `test_deploy_cloud_run_apply_calls_gcloud_deploy` — asserts `gcloud builds submit --tag ...` and `gcloud run deploy <svc> --image ... --region ... --project ...` both fire.
- `test_deploy_cloud_run_apply_respects_profile_interpolation` — profile with `image = \"${VEX_IMAGE_REPO}/app\"` + memory/cpu/min/max/service_account; asserts interpolated image and profile fields reach the gcloud argv.
- `test_deploy_cloud_run_apply_runs_preflight_first` — mocks `deploy_preflight` to return 2 issues; asserts gcloud subprocess is never called and exit is non-zero.
- `test_deploy_docker_run_builds_and_runs_image` — asserts `docker build` then `docker run --rm -p 8080:8080 <image>:<tag>` with the passed `--port`.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — all 46 tests pass locally.
- [ ] Integration test follow-up: real `modal deploy` and `gcloud run deploy` against sandbox projects (out of scope for this PR).

none