### PR TITLE
feat: vex eval gains promptfoo adapter, --json output, and CI gate (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Every verb is a thin wrapper. Escape hatches everywhere — if you want `uv run 
 - `vex init inference-api <path>` — FastAPI + uvicorn + typed schemas
 - `vex benchmark --command ... --runs ... --warmup ...` — harness with warmup control and JSON output
 - `vex eval --command ...` and `vex eval --per-case --command "... {input} ..."` — dataset-driven checks
+- `vex eval` auto-delegates to [`promptfoo`](https://www.promptfoo.dev) via `uvx` when `promptfooconfig.yaml` is present. Use `--no-promptfoo` to force the built-in harness, `--json` for machine-readable output, and `--min-pass-rate 0.9` to gate CI on a fraction of passing cases. Override defaults in `[tool.vex.eval]` (`adapter = "auto"|"promptfoo"|"harness"`, `min_pass_rate = 0.9`).
 - `vex policy list|get|set|unset` — inspect and override `[tool.vex.policy]`
 - `vex run --sandbox ...` — Docker/Podman-backed execution with `--cap-drop ALL`, `--network none`, read-only rootfs, memory + pids caps
 - `vex package-model <model.onnx>` — versioned manifest with compatibility metadata:

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -10,6 +10,7 @@ import shutil
 import statistics
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 from pathlib import Path
@@ -249,6 +250,22 @@ def load_vex_scripts(root: Path) -> dict[str, str]:
     if not isinstance(scripts, dict):
         return {}
     return {str(key): str(value) for key, value in scripts.items()}
+
+
+def load_vex_eval_config(root: Path) -> dict[str, Any]:
+    data = load_pyproject(root)
+    config = data.get("tool", {}).get("vex", {}).get("eval", {})
+    if not isinstance(config, dict):
+        return {}
+    return {str(key): value for key, value in config.items()}
+
+
+def detect_promptfoo_config(root: Path) -> Path | None:
+    for candidate in ("promptfooconfig.yaml", "promptfooconfig.yml"):
+        path = root / candidate
+        if path.exists() and path.is_file():
+            return path
+    return None
 
 
 def load_vex_policy(root: Path) -> dict[str, object]:
@@ -1333,7 +1350,259 @@ def run_benchmark_harness(root: Path, command: str, runs: int, warmup: int, out_
     return 0 if all(code == 0 for code in exit_codes) else 1
 
 
-def run_eval_harness(root: Path, command: str, dataset_path: Path, out_path: Path) -> int:
+def _emit_eval_report(report: dict[str, Any], out_path: Path, emit_json: bool) -> None:
+    """Write report to file and either print JSON or a human summary."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if emit_json:
+        print(json.dumps(report))
+
+
+def _apply_min_pass_rate(report: dict[str, Any], threshold: float | None, exit_code: int) -> int:
+    """Return updated exit code after applying the min pass-rate gate.
+
+    Threshold is a fraction 0.0-1.0; compared against ``pass_rate`` stored as a
+    percent (0-100) inside the report, consistent with the existing per-case
+    schema.
+    """
+    if threshold is None:
+        return exit_code
+    pass_rate_percent = report.get("pass_rate", 0.0)
+    if not isinstance(pass_rate_percent, (int, float)):
+        pass_rate_percent = 0.0
+    target_percent = threshold * 100
+    if pass_rate_percent < target_percent:
+        print(
+            f"FAIL pass_rate={pass_rate_percent}% below --min-pass-rate "
+            f"{target_percent}% gate"
+        )
+        return 1 if exit_code == 0 else exit_code
+    return exit_code
+
+
+def _promptfoo_binary() -> tuple[list[str], str] | None:
+    """Resolve a command list capable of invoking promptfoo.
+
+    Prefers ``uvx`` (already required as part of the ``uv`` toolchain) and
+    falls back to a system ``promptfoo`` on PATH.
+    """
+    uvx = shutil.which("uvx")
+    if uvx:
+        return [uvx, "promptfoo"], "uvx"
+    promptfoo = shutil.which("promptfoo")
+    if promptfoo:
+        return [promptfoo], "promptfoo"
+    return None
+
+
+def normalize_promptfoo_report(
+    raw: dict[str, Any],
+    *,
+    command: str | None,
+    dataset_path: Path,
+    config_path: Path,
+) -> dict[str, Any]:
+    """Map a promptfoo JSON output to the vex-eval/v1 schema.
+
+    promptfoo's schema varies across versions; we look at ``results`` and
+    ``results.results`` (v0.x nests results under a top-level key) and fall
+    back to sensible defaults when keys are missing.
+    """
+    payload: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    nested = payload.get("results")
+    if isinstance(nested, dict):
+        payload = nested
+
+    raw_cases: Any = payload.get("results")
+    if not isinstance(raw_cases, list):
+        raw_cases = []
+
+    normalized_cases: list[dict[str, Any]] = []
+    passed = 0
+    for index, case in enumerate(raw_cases, start=1):
+        if not isinstance(case, dict):
+            continue
+        success = bool(case.get("success", case.get("pass", False)))
+        if success:
+            passed += 1
+
+        prompt = case.get("prompt") or {}
+        if isinstance(prompt, dict):
+            input_text = str(prompt.get("raw") or prompt.get("display") or "")
+        else:
+            input_text = str(prompt or "")
+        vars_value = case.get("vars")
+        if not input_text and isinstance(vars_value, dict):
+            input_text = json.dumps(vars_value, sort_keys=True)
+
+        response = case.get("response") or {}
+        output_text = ""
+        if isinstance(response, dict):
+            output_text = str(response.get("output", ""))
+        if not output_text and "output" in case:
+            output_text = str(case.get("output", ""))
+
+        provider: Any = case.get("provider")
+        if isinstance(provider, dict):
+            provider_id = str(provider.get("id") or provider.get("label") or "")
+        elif isinstance(provider, str):
+            provider_id = provider
+        else:
+            provider_id = ""
+
+        latency_ms: float | None = None
+        for key in ("latencyMs", "latency_ms", "tokensPerSecond"):
+            raw_latency = case.get(key)
+            if isinstance(raw_latency, (int, float)):
+                latency_ms = float(raw_latency)
+                break
+
+        score = case.get("score")
+        normalized_cases.append(
+            {
+                "index": index,
+                "input": input_text,
+                "output": output_text,
+                "passed": success,
+                "provider": provider_id,
+                "latency_ms": latency_ms,
+                "score": score if isinstance(score, (int, float)) else None,
+            }
+        )
+
+    failed = len(normalized_cases) - passed
+    pass_rate = round((passed / len(normalized_cases)) * 100, 2) if normalized_cases else 0.0
+
+    return {
+        "schema": "vex-eval/v1",
+        "adapter": "promptfoo",
+        "mode": "promptfoo",
+        "command": command,
+        "config": str(config_path),
+        "dataset": str(dataset_path),
+        "dataset_case_count": len(normalized_cases),
+        "passed": passed,
+        "failed": failed,
+        "pass_rate": pass_rate,
+        "results": normalized_cases,
+    }
+
+
+def run_eval_promptfoo_adapter(
+    root: Path,
+    config_path: Path,
+    dataset_path: Path,
+    out_path: Path,
+    *,
+    timeout: float,
+    emit_json: bool,
+    min_pass_rate: float | None,
+) -> int:
+    """Delegate to a locally discovered ``promptfoo`` binary."""
+    binary = _promptfoo_binary()
+    if binary is None:
+        print(
+            "vex eval promptfoo adapter requires 'uvx' or 'promptfoo' on PATH. "
+            "Install uv (https://docs.astral.sh/uv/) or pass --no-promptfoo to "
+            "use the Python harness."
+        )
+        return 127
+    command_list, runner_name = binary
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".json", prefix="vex-promptfoo-", delete=False
+    ) as tmp_file:
+        tmp_output = Path(tmp_file.name)
+
+    try:
+        argv = [
+            *command_list,
+            "eval",
+            "-c",
+            str(config_path),
+            "--output",
+            str(tmp_output),
+        ]
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            print(
+                f"promptfoo adapter timed out after {timeout}s "
+                f"(runner={runner_name}). Increase --timeout if needed."
+            )
+            return 124
+        except FileNotFoundError:
+            print(f"promptfoo adapter failed: {runner_name} not found")
+            return 127
+
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+
+        raw_report: dict[str, Any] = {}
+        if tmp_output.exists():
+            raw_text = tmp_output.read_text(encoding="utf-8")
+            if raw_text.strip():
+                try:
+                    parsed = json.loads(raw_text)
+                    if isinstance(parsed, dict):
+                        raw_report = parsed
+                except json.JSONDecodeError:
+                    raw_report = {}
+    finally:
+        try:
+            tmp_output.unlink()
+        except OSError:
+            pass
+
+    if completed.returncode != 0 and not raw_report:
+        # Surface subprocess output clearly so CI logs are actionable.
+        if stdout.strip():
+            print(stdout.rstrip())
+        if stderr.strip():
+            print(stderr.rstrip(), file=sys.stderr)
+        print(
+            f"promptfoo exited with code {completed.returncode} "
+            f"(runner={runner_name})"
+        )
+        return completed.returncode if completed.returncode != 0 else 1
+
+    report = normalize_promptfoo_report(
+        raw_report,
+        command=f"{runner_name} promptfoo",
+        dataset_path=dataset_path,
+        config_path=config_path,
+    )
+
+    _emit_eval_report(report, out_path, emit_json)
+    if not emit_json:
+        print(f"Eval report written to {out_path}")
+        print(
+            f"adapter=promptfoo passed={report['passed']} failed={report['failed']} "
+            f"pass_rate={report['pass_rate']}%"
+        )
+
+    exit_code = completed.returncode
+    if exit_code == 0 and report["failed"] > 0:
+        exit_code = 1
+    return _apply_min_pass_rate(report, min_pass_rate, exit_code)
+
+
+def run_eval_harness(
+    root: Path,
+    command: str,
+    dataset_path: Path,
+    out_path: Path,
+    *,
+    emit_json: bool = False,
+    min_pass_rate: float | None = None,
+) -> int:
     uv = uv_bin()
     if uv is None:
         print("vex eval requires 'uv' on PATH")
@@ -1350,6 +1619,7 @@ def run_eval_harness(root: Path, command: str, dataset_path: Path, out_path: Pat
 
     report = {
         "schema": "vex-eval/v1",
+        "adapter": "harness",
         "command": command,
         "dataset": str(dataset_path),
         "dataset_exists": dataset_exists,
@@ -1357,13 +1627,18 @@ def run_eval_harness(root: Path, command: str, dataset_path: Path, out_path: Pat
         "exit_code": code,
         "duration_ms": elapsed_ms,
         "status": "passed" if code == 0 else "failed",
+        "passed": case_count if code == 0 else 0,
+        "failed": 0 if code == 0 else case_count,
+        "pass_rate": 100.0 if code == 0 else 0.0,
+        "results": [],
     }
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
-    print(f"Eval report written to {out_path}")
-    print(f"status={report['status']} duration={elapsed_ms}ms cases={case_count}")
-    return 0 if code == 0 else 1
+    _emit_eval_report(report, out_path, emit_json)
+    if not emit_json:
+        print(f"Eval report written to {out_path}")
+        print(f"status={report['status']} duration={elapsed_ms}ms cases={case_count}")
+    exit_code = 0 if code == 0 else 1
+    return _apply_min_pass_rate(report, min_pass_rate, exit_code)
 
 
 def load_eval_cases(dataset_path: Path) -> list[dict[str, Any]]:
@@ -1382,7 +1657,15 @@ def load_eval_cases(dataset_path: Path) -> list[dict[str, Any]]:
     return cases
 
 
-def run_eval_per_case_harness(root: Path, command: str, dataset_path: Path, out_path: Path) -> int:
+def run_eval_per_case_harness(
+    root: Path,
+    command: str,
+    dataset_path: Path,
+    out_path: Path,
+    *,
+    emit_json: bool = False,
+    min_pass_rate: float | None = None,
+) -> int:
     uv = uv_bin()
     if uv is None:
         print("vex eval requires 'uv' on PATH")
@@ -1459,6 +1742,7 @@ def run_eval_per_case_harness(root: Path, command: str, dataset_path: Path, out_
 
     report = {
         "schema": "vex-eval/v1",
+        "adapter": "harness",
         "mode": "per-case",
         "command": command,
         "dataset": str(dataset_path),
@@ -1469,11 +1753,15 @@ def run_eval_per_case_harness(root: Path, command: str, dataset_path: Path, out_
         "results": results,
     }
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
-    print(f"Eval report written to {out_path}")
-    print(f"mode=per-case passed={report['passed']} failed={report['failed']} pass_rate={report['pass_rate']}%")
-    return 0 if report["failed"] == 0 else 1
+    _emit_eval_report(report, out_path, emit_json)
+    if not emit_json:
+        print(f"Eval report written to {out_path}")
+        print(
+            f"mode=per-case passed={report['passed']} failed={report['failed']} "
+            f"pass_rate={report['pass_rate']}%"
+        )
+    exit_code = 0 if report["failed"] == 0 else 1
+    return _apply_min_pass_rate(report, min_pass_rate, exit_code)
 
 
 def docker_like_bin() -> str | None:
@@ -1718,6 +2006,31 @@ def build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument("--dataset", default="evals/datasets/cases.jsonl")
     eval_parser.add_argument("--out", default="artifacts/evals/latest.json")
     eval_parser.add_argument("--per-case", action="store_true")
+    eval_parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Print the normalized report JSON to stdout (suppresses the human summary).",
+    )
+    eval_parser.add_argument(
+        "--min-pass-rate",
+        dest="min_pass_rate",
+        type=float,
+        default=None,
+        help="Fail the run when pass_rate falls below this fraction (0.0-1.0).",
+    )
+    eval_parser.add_argument(
+        "--no-promptfoo",
+        dest="no_promptfoo",
+        action="store_true",
+        help="Force the built-in Python harness even if promptfooconfig.yaml exists.",
+    )
+    eval_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Timeout (seconds) for the promptfoo subprocess (default: 300).",
+    )
     eval_parser.add_argument("args", nargs=argparse.REMAINDER)
     eval_parser.set_defaults(handler=handle_eval)
 
@@ -1915,6 +2228,62 @@ def handle_benchmark(args: argparse.Namespace) -> int:
 
 def handle_eval(args: argparse.Namespace) -> int:
     root = project_root()
+    eval_config = load_vex_eval_config(root)
+
+    # --min-pass-rate: CLI flag wins, pyproject is the fallback default.
+    min_pass_rate: float | None = args.min_pass_rate
+    if min_pass_rate is None:
+        configured = eval_config.get("min_pass_rate")
+        if isinstance(configured, (int, float)):
+            min_pass_rate = float(configured)
+    if min_pass_rate is not None:
+        if min_pass_rate < 0.0 or min_pass_rate > 1.0:
+            print(
+                "--min-pass-rate must be a fraction between 0.0 and 1.0 "
+                f"(got {min_pass_rate})"
+            )
+            return 2
+
+    # Adapter selection precedence:
+    # 1. explicit --command -> always use harness
+    # 2. --no-promptfoo CLI flag -> always use harness
+    # 3. [tool.vex.eval].adapter = "harness" | "promptfoo" | "auto"
+    # 4. "auto": delegate when promptfooconfig.yaml is present
+    adapter_setting = str(eval_config.get("adapter", "auto")).lower()
+    if adapter_setting not in {"auto", "promptfoo", "harness"}:
+        adapter_setting = "auto"
+
+    explicit_command = args.command is not None
+    use_promptfoo = False
+    config_path: Path | None = None
+
+    if not explicit_command and not args.no_promptfoo:
+        if adapter_setting == "promptfoo":
+            config_path = detect_promptfoo_config(root)
+            if config_path is None:
+                print(
+                    "vex eval adapter='promptfoo' but no promptfooconfig.yaml "
+                    "was found at the project root"
+                )
+                return 2
+            use_promptfoo = True
+        elif adapter_setting == "auto":
+            config_path = detect_promptfoo_config(root)
+            use_promptfoo = config_path is not None
+
+    if use_promptfoo and config_path is not None:
+        dataset_path = root / args.dataset
+        out_path = root / args.out
+        return run_eval_promptfoo_adapter(
+            root,
+            config_path=config_path,
+            dataset_path=dataset_path,
+            out_path=out_path,
+            timeout=max(1.0, float(args.timeout)),
+            emit_json=bool(args.emit_json),
+            min_pass_rate=min_pass_rate,
+        )
+
     command = args.command
     if command is None:
         command = resolve_optional_script_command("eval", root)
@@ -1928,8 +2297,22 @@ def handle_eval(args: argparse.Namespace) -> int:
     dataset_path = root / args.dataset
     out_path = root / args.out
     if args.per_case:
-        return run_eval_per_case_harness(root, command, dataset_path=dataset_path, out_path=out_path)
-    return run_eval_harness(root, command, dataset_path=dataset_path, out_path=out_path)
+        return run_eval_per_case_harness(
+            root,
+            command,
+            dataset_path=dataset_path,
+            out_path=out_path,
+            emit_json=bool(args.emit_json),
+            min_pass_rate=min_pass_rate,
+        )
+    return run_eval_harness(
+        root,
+        command,
+        dataset_path=dataset_path,
+        out_path=out_path,
+        emit_json=bool(args.emit_json),
+        min_pass_rate=min_pass_rate,
+    )
 
 
 def handle_policy(args: argparse.Namespace) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -787,6 +787,307 @@ class CliTests(unittest.TestCase):
         self.assertEqual(report["results"][0]["exact_ok"], True)
         self.assertEqual(report["results"][1]["json_path_ok"], True)
 
+    @patch("vex.cli.shutil.which")
+    @patch("vex.cli.subprocess.run")
+    def test_eval_detects_promptfoo_config(
+        self, subprocess_run: object, which_mock: object
+    ) -> None:
+        which_mock.side_effect = lambda name: "/usr/local/bin/uvx" if name == "uvx" else None
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+            output_path = Path(argv[argv.index("--output") + 1])
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "results": {
+                            "results": [
+                                {
+                                    "success": True,
+                                    "prompt": {"raw": "hello"},
+                                    "response": {"output": "hi"},
+                                    "provider": {"id": "openai:gpt-4o-mini"},
+                                    "latencyMs": 123,
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return _Completed()
+
+        subprocess_run.side_effect = _fake_run
+
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "promptfooconfig.yaml").write_text("providers: []\n", encoding="utf-8")
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    ["eval", "--out", "artifacts/evals/promptfoo.json"]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "promptfoo.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(code, 0)
+        self.assertIn("adapter=promptfoo", output)
+        self.assertEqual(report["adapter"], "promptfoo")
+        self.assertEqual(subprocess_run.call_count, 1)
+        invoked_argv = subprocess_run.call_args.args[0]
+        self.assertEqual(invoked_argv[:4], ["/usr/local/bin/uvx", "promptfoo", "eval", "-c"])
+        self.assertIn("--output", invoked_argv)
+
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command_capture", return_value=(0, "out", ""))
+    def test_eval_no_promptfoo_flag_uses_harness(
+        self, run_capture: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "promptfooconfig.yaml").write_text("providers: []\n", encoding="utf-8")
+            (root / "evals" / "datasets").mkdir(parents=True)
+            (root / "evals" / "datasets" / "cases.jsonl").write_text(
+                '{"input":"a"}\n', encoding="utf-8"
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--no-promptfoo",
+                        "--per-case",
+                        "--command",
+                        "echo {input}",
+                        "--out",
+                        "artifacts/evals/forced.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "forced.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(code, 0)
+        self.assertIn("mode=per-case", output)
+        self.assertEqual(report["adapter"], "harness")
+        self.assertEqual(report["mode"], "per-case")
+        run_capture.assert_called_once()
+
+    @patch("vex.cli.shutil.which")
+    @patch("vex.cli.subprocess.run")
+    def test_eval_normalizes_promptfoo_results(
+        self, subprocess_run: object, which_mock: object
+    ) -> None:
+        which_mock.side_effect = lambda name: "/usr/local/bin/uvx" if name == "uvx" else None
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        fake_payload = {
+            "results": {
+                "results": [
+                    {
+                        "success": True,
+                        "prompt": {"raw": "case-1"},
+                        "response": {"output": "ok"},
+                        "provider": "openai:gpt-4o-mini",
+                        "latencyMs": 42,
+                    },
+                    {
+                        "success": False,
+                        "prompt": {"raw": "case-2"},
+                        "response": {"output": "bad"},
+                        "provider": {"id": "openai:gpt-4o-mini"},
+                    },
+                    {
+                        "success": True,
+                        "vars": {"topic": "cats"},
+                        "output": "meow",
+                    },
+                ]
+            }
+        }
+
+        def _fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+            output_path = Path(argv[argv.index("--output") + 1])
+            output_path.write_text(json.dumps(fake_payload), encoding="utf-8")
+            return _Completed()
+
+        subprocess_run.side_effect = _fake_run
+
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "promptfooconfig.yaml").write_text("providers: []\n", encoding="utf-8")
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(
+                    ["eval", "--out", "artifacts/evals/norm.json"]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "norm.json").read_text(encoding="utf-8")
+            )
+
+        # 2/3 passed => overall harness would still flag failure (exit 1).
+        self.assertEqual(code, 1)
+        self.assertEqual(report["schema"], "vex-eval/v1")
+        self.assertEqual(report["adapter"], "promptfoo")
+        self.assertEqual(report["passed"], 2)
+        self.assertEqual(report["failed"], 1)
+        self.assertAlmostEqual(report["pass_rate"], 66.67, places=2)
+        self.assertEqual(len(report["results"]), 3)
+        self.assertEqual(report["results"][0]["input"], "case-1")
+        self.assertEqual(report["results"][0]["output"], "ok")
+        self.assertEqual(report["results"][0]["provider"], "openai:gpt-4o-mini")
+        self.assertEqual(report["results"][0]["latency_ms"], 42.0)
+        self.assertEqual(report["results"][0]["passed"], True)
+        self.assertEqual(report["results"][1]["passed"], False)
+
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command_capture")
+    def test_eval_min_pass_rate_gates(
+        self, run_capture: object, _uv_bin: object
+    ) -> None:
+        run_capture.side_effect = [
+            (0, "hit", ""),
+            (1, "miss", ""),
+            (1, "miss", ""),
+        ]
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "evals" / "datasets").mkdir(parents=True)
+            (root / "evals" / "datasets" / "cases.jsonl").write_text(
+                '{"input":"a","expect_contains":"hit"}\n'
+                '{"input":"b","expect_contains":"hit"}\n'
+                '{"input":"c","expect_contains":"hit"}\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--per-case",
+                        "--command",
+                        "echo {input}",
+                        "--min-pass-rate",
+                        "0.5",
+                        "--out",
+                        "artifacts/evals/gate.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "gate.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(report["passed"], 1)
+        self.assertEqual(report["failed"], 2)
+        self.assertIn("below --min-pass-rate", output)
+
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command_capture")
+    def test_eval_min_pass_rate_passes_when_above_threshold(
+        self, run_capture: object, _uv_bin: object
+    ) -> None:
+        run_capture.side_effect = [
+            (0, "hit", ""),
+            (0, "hit", ""),
+            (1, "miss", ""),
+        ]
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "evals" / "datasets").mkdir(parents=True)
+            (root / "evals" / "datasets" / "cases.jsonl").write_text(
+                '{"input":"a","expect_contains":"hit"}\n'
+                '{"input":"b","expect_contains":"hit"}\n'
+                '{"input":"c","expect_contains":"hit"}\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--per-case",
+                        "--command",
+                        "echo {input}",
+                        "--min-pass-rate",
+                        "0.5",
+                        "--out",
+                        "artifacts/evals/gate-pass.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        # 2/3 = 66% which is above the 50% gate, but one case hard-failed
+        # so the raw harness still exits 1. The gate itself does not fire.
+        self.assertEqual(code, 1)
+        self.assertNotIn("below --min-pass-rate", output)
+
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command_capture", return_value=(0, "hit", ""))
+    def test_eval_json_flag_prints_report_to_stdout(
+        self, run_capture: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "evals" / "datasets").mkdir(parents=True)
+            (root / "evals" / "datasets" / "cases.jsonl").write_text(
+                '{"input":"a","expect_contains":"hit"}\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--per-case",
+                        "--command",
+                        "echo {input}",
+                        "--json",
+                        "--out",
+                        "artifacts/evals/json.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        # Must be a single JSON document — parseable without tweaks.
+        payload = json.loads(output.strip())
+        self.assertEqual(payload["schema"], "vex-eval/v1")
+        self.assertEqual(payload["adapter"], "harness")
+        self.assertEqual(payload["mode"], "per-case")
+        self.assertEqual(payload["passed"], 1)
+        # Human-friendly summary suppressed when --json is set.
+        self.assertNotIn("Eval report written", output)
+
     @patch("vex.cli.docker_like_bin", return_value="docker")
     @patch("vex.cli.run_command", return_value=0)
     def test_deploy_docker_builds_image(self, run_command: object, _docker: object) -> None:


### PR DESCRIPTION
## Summary

Makes `vex eval` a CI-gradeable entry point by adding a first-class
promptfoo adapter, a machine-readable output mode, and a pass-rate gate
that works across every adapter.

## Behavior modes (precedence order)

1. **Explicit `--command` (or `[tool.vex.scripts].eval`)** — the existing
   Python harness, untouched. Both the default and `--per-case` harness
   now stamp `adapter: "harness"` on their reports.
2. **`--no-promptfoo`** — force the harness even when
   `promptfooconfig.yaml` exists.
3. **`[tool.vex.eval].adapter = "harness" | "promptfoo" | "auto"`** —
   pyproject-level opt-in/opt-out. `auto` (default) detects the config.
4. **Auto-detected promptfoo** — if `promptfooconfig.yaml`(.yml) sits at
   the project root and no `--command` is passed, `vex` shells out to
   `uvx promptfoo eval -c <config> --output <tmp>.json`, falling back
   to a system `promptfoo` on `PATH`. Promptfoo's JSON is normalized
   into the existing `vex-eval/v1` schema (`passed`, `failed`,
   `pass_rate`, `results[]` with `input`, `output`, `provider`,
   `latency_ms`, `score`), with `adapter: "promptfoo"` so downstream
   consumers can distinguish modes.

## Flags added to `vex eval`

- `--json` — emit the normalized report JSON to stdout (suppresses the
  human summary). Works for promptfoo adapter, per-case harness, and the
  default harness.
- `--min-pass-rate <fraction>` — fail the run when `pass_rate` falls
  below `fraction * 100`. Fraction (0.0–1.0) to match the existing
  `pass_rate` percent value already stored in the report.
- `--no-promptfoo` — force the built-in harness.
- `--timeout <seconds>` — timeout for the promptfoo subprocess
  (default 300s).

## Flag precedence

1. CLI flags (`--min-pass-rate`, `--no-promptfoo`, `--command`)
2. `[tool.vex.eval]` in `pyproject.toml`
3. Auto-detection

## Constraints honored

- `promptfoo` is NOT added as a Python dependency — invoked as a
  subprocess via `uvx`, with a system `promptfoo` fallback.
- Schema stays at `vex-eval/v1`; fields were added, none renamed.
- Existing `handle_eval` tests (explicit `--command`, `--per-case`) still
  pass unchanged.

## Test plan

- [x] `test_eval_detects_promptfoo_config` — auto-detection shells out to
      `uvx promptfoo eval -c ... --output ...`.
- [x] `test_eval_no_promptfoo_flag_uses_harness` — `--no-promptfoo` plus
      `promptfooconfig.yaml` still runs the per-case harness.
- [x] `test_eval_normalizes_promptfoo_results` — promptfoo JSON (nested
      `results.results` shape) normalizes to `passed=2`, `failed=1`,
      `adapter=promptfoo`, with per-case `input`, `output`, `provider`,
      `latency_ms`.
- [x] `test_eval_min_pass_rate_gates` — per-case run with 1/3 passing
      and `--min-pass-rate 0.5` surfaces the gate message and exits 1.
- [x] `test_eval_min_pass_rate_passes_when_above_threshold` — 2/3
      passing with threshold `0.5` keeps the raw harness exit (1 from a
      hard failure) without a gate message.
- [x] `test_eval_json_flag_prints_report_to_stdout` — `--json` prints a
      single valid JSON document and suppresses the human summary.
- [x] All 42 pre-existing tests still pass (48 total now).

```
PYTHONPATH=src python3 -m unittest tests.test_cli
# Ran 48 tests in 0.3s  OK
```

Closes #9

none