### PR TITLE
feat: vex dev gains watchfiles reload + provider banner (#8)

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -1702,6 +1702,14 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.set_defaults(handler=handle_init)
 
     dev_parser = subparsers.add_parser("dev", help=COMMAND_HELP["dev"])
+    dev_parser.add_argument("--no-reload", dest="no_reload", action="store_true")
+    dev_parser.add_argument("--watch", dest="watch", action="append", default=[])
+    dev_parser.add_argument(
+        "--provider-check",
+        dest="provider_check",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     dev_parser.add_argument("args", nargs=argparse.REMAINDER)
     dev_parser.set_defaults(handler=handle_dev)
 
@@ -1896,12 +1904,183 @@ def handle_init(args: argparse.Namespace) -> int:
     return code
 
 
+_DEV_PROVIDER_ENV_KEYS: tuple[tuple[str, str], ...] = (
+    ("OPENAI_API_KEY", "openai"),
+    ("ANTHROPIC_API_KEY", "anthropic"),
+)
+
+
+def resolve_dev_provider(env: dict[str, str] | None = None) -> str:
+    """Mirror the scaffolded settings.py provider resolution.
+
+    OPENAI_API_KEY -> openai, ANTHROPIC_API_KEY -> anthropic, else ollama.
+    """
+    source = os.environ if env is None else env
+    for key, name in _DEV_PROVIDER_ENV_KEYS:
+        if source.get(key):
+            return name
+    return "ollama"
+
+
+def dev_provider_banner_lines(
+    env: dict[str, str] | None = None,
+    which: object = None,
+) -> list[str]:
+    """Build the one-or-two-line provider banner emitted at `vex dev` start."""
+    provider = resolve_dev_provider(env)
+    lines = [f"[vex dev] provider={provider}"]
+    if provider == "ollama":
+        which_fn = which if which is not None else shutil.which
+        if which_fn("ollama") is None:
+            lines.append(
+                "[vex dev] ollama not on PATH — install from https://ollama.com "
+                "or set OPENAI_API_KEY / ANTHROPIC_API_KEY"
+            )
+    return lines
+
+
+def load_vex_dev_watch_paths(root: Path) -> list[str]:
+    """Read `[tool.vex.dev].watch` from pyproject.toml if present.
+
+    Accepts a list of strings. Anything else is ignored.
+    """
+    data = load_pyproject(root)
+    dev = data.get("tool", {}).get("vex", {}).get("dev", {})
+    if not isinstance(dev, dict):
+        return []
+    watch = dev.get("watch")
+    if not isinstance(watch, list):
+        return []
+    return [str(item) for item in watch if isinstance(item, (str, os.PathLike))]
+
+
+def resolve_dev_watch_paths(
+    extra_paths: Sequence[str],
+    root: Path,
+) -> list[Path]:
+    """Resolve watch paths for `vex dev --reload`.
+
+    Order: `src/` (if it exists), pyproject `[tool.vex.dev].watch`, `--watch` flags.
+    Non-existent paths are skipped. Duplicates removed, preserving first occurrence.
+    """
+    candidates: list[str] = []
+    src_dir = root / "src"
+    if src_dir.is_dir():
+        candidates.append(str(src_dir))
+    candidates.extend(load_vex_dev_watch_paths(root))
+    candidates.extend(extra_paths)
+
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+    for raw in candidates:
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = (root / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        if candidate in seen:
+            continue
+        if not candidate.exists():
+            continue
+        seen.add(candidate)
+        resolved.append(candidate)
+    return resolved
+
+
+def _try_import_watchfiles() -> Any:
+    try:
+        import watchfiles  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    return watchfiles
+
+
+def run_dev_with_reload(
+    uv_args: list[str],
+    watch_paths: Sequence[Path],
+    watchfiles_module: Any = None,
+) -> int:
+    """Start the dev command and restart it whenever a watched path changes.
+
+    Graceful shutdown: SIGTERM, wait up to 3s, then SIGKILL.
+    """
+    if watchfiles_module is None:
+        watchfiles_module = _try_import_watchfiles()
+    if watchfiles_module is None:
+        print(
+            "[vex dev] 'watchfiles' is not installed — running without reload "
+            "(install with: uv add watchfiles)"
+        )
+        return run_uv(uv_args)
+
+    uv = uv_bin()
+    if uv is None:
+        print("vex requires 'uv' on PATH", file=sys.stderr)
+        return 127
+
+    if not watch_paths:
+        print("[vex dev] no watch paths found — running without reload")
+        return run_uv(uv_args)
+
+    argv = [uv, *uv_args]
+    str_paths = [str(p) for p in watch_paths]
+    print(f"[vex dev] watching {len(str_paths)} path(s) for changes")
+
+    def _spawn() -> subprocess.Popen[bytes]:
+        return subprocess.Popen(argv)
+
+    def _shutdown(proc: subprocess.Popen[bytes]) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+
+    proc = _spawn()
+    try:
+        for _changes in watchfiles_module.watch(*str_paths):
+            print("[vex dev] change detected — restarting")
+            _shutdown(proc)
+            proc = _spawn()
+    except KeyboardInterrupt:
+        _shutdown(proc)
+        return 130
+    finally:
+        _shutdown(proc)
+
+    return proc.returncode if proc.returncode is not None else 0
+
+
 def handle_dev(args: argparse.Namespace) -> int:
-    uv_args = resolve_required_script_args("dev", args.args, project_root())
+    root = project_root()
+    provider_check = getattr(args, "provider_check", True)
+    if provider_check:
+        for line in dev_provider_banner_lines():
+            print(line)
+
+    uv_args = resolve_required_script_args("dev", args.args, root)
     if uv_args is None:
         print("vex dev requires [tool.vex.scripts].dev in pyproject.toml")
         return 2
-    return run_uv(uv_args)
+
+    if getattr(args, "no_reload", False):
+        return run_uv(uv_args)
+
+    extra_watch = list(getattr(args, "watch", []) or [])
+    watch_paths = resolve_dev_watch_paths(extra_watch, root)
+    return run_dev_with_reload(uv_args, watch_paths)
 
 
 def handle_benchmark(args: argparse.Namespace) -> int:
@@ -2195,6 +2374,27 @@ def main(argv: Sequence[str] | None = None) -> int:
             index = 1
             while index < len(raw_argv) and raw_argv[index] in {"--sandbox"}:
                 index += 1
+            args.args = raw_argv[index:]
+        elif getattr(args, "command", None) == "dev":
+            index = 1
+            dev_flag_values = {"--watch"}
+            dev_flag_switches = {
+                "--no-reload",
+                "--provider-check",
+                "--no-provider-check",
+            }
+            while index < len(raw_argv):
+                token = raw_argv[index]
+                if token in dev_flag_switches:
+                    index += 1
+                    continue
+                if token in dev_flag_values:
+                    index += 2
+                    continue
+                if token.startswith("--watch="):
+                    index += 1
+                    continue
+                break
             args.args = raw_argv[index:]
         else:
             args.args = raw_argv[1:]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("AI-native workflow tool for Python apps.", output)
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("vex.cli.uv_bin", return_value="uv")
     @patch("vex.cli.run_command", return_value=0)
     def test_dev_command_uses_script_alias(self, run_command: object, _uv_bin: object) -> None:
@@ -37,7 +38,7 @@ class CliTests(unittest.TestCase):
             )
             os.chdir(temp_dir)
             try:
-                code, _output = self.run_cli(["dev", "--bind", "127.0.0.1"])
+                code, _output = self.run_cli(["dev", "--no-reload", "--bind", "127.0.0.1"])
             finally:
                 os.chdir(original_cwd)
 
@@ -46,6 +47,204 @@ class CliTests(unittest.TestCase):
             ["uv", "run", "sh", "-c", "python -m http.server --bind 127.0.0.1"],
             cwd=None,
         )
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_banner_prints_openai_when_openai_key_set(
+        self, _run_command: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["dev", "--no-reload"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("provider=openai", output)
+        self.assertNotIn("provider=ollama", output)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.shutil.which")
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_banner_prints_ollama_when_ollama_on_path(
+        self, _run_command: object, _uv_bin: object, which: object
+    ) -> None:
+        which.return_value = "/usr/local/bin/ollama"
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["dev", "--no-reload"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("provider=ollama", output)
+        self.assertNotIn("ollama not on PATH", output)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.shutil.which")
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_banner_prints_install_pointer_when_no_keys_and_no_ollama(
+        self, _run_command: object, _uv_bin: object, which: object
+    ) -> None:
+        which.return_value = None
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["dev", "--no-reload"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("provider=ollama", output)
+        self.assertIn("ollama not on PATH", output)
+        self.assertIn("https://ollama.com", output)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_flags_are_not_leaked_into_script_args(
+        self, run_command: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            (Path(temp_dir) / "extra").mkdir()
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(
+                    ["dev", "--no-reload", "--watch", "extra", "--bind", "127.0.0.1"]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        run_command.assert_called_once_with(
+            ["uv", "run", "sh", "-c", "python -m http.server --bind 127.0.0.1"],
+            cwd=None,
+        )
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_no_provider_check_suppresses_banner(
+        self, _run_command: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["dev", "--no-provider-check", "--no-reload"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertNotIn("[vex dev] provider=", output)
+
+    def test_resolve_dev_watch_paths_includes_flag_paths(self) -> None:
+        from vex.cli import resolve_dev_watch_paths
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "src").mkdir()
+            (root / "extra").mkdir()
+            paths = resolve_dev_watch_paths(["extra"], root)
+
+        resolved = [p.name for p in paths]
+        self.assertIn("src", resolved)
+        self.assertIn("extra", resolved)
+
+    def test_resolve_dev_watch_paths_reads_pyproject_dev_watch(self) -> None:
+        from vex.cli import resolve_dev_watch_paths
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "src").mkdir()
+            (root / "prompts").mkdir()
+            (root / "pyproject.toml").write_text(
+                "[tool.vex.dev]\nwatch = [\"prompts\"]\n",
+                encoding="utf-8",
+            )
+            paths = resolve_dev_watch_paths([], root)
+
+        resolved = [p.name for p in paths]
+        self.assertIn("src", resolved)
+        self.assertIn("prompts", resolved)
+
+    def test_resolve_dev_watch_paths_skips_missing_paths(self) -> None:
+        from vex.cli import resolve_dev_watch_paths
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            paths = resolve_dev_watch_paths(["does-not-exist"], root)
+
+        self.assertEqual(paths, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_uv", return_value=0)
+    def test_dev_falls_back_to_no_reload_when_watchfiles_missing(
+        self, run_uv: object, _uv_bin: object
+    ) -> None:
+        from vex.cli import run_dev_with_reload
+
+        uv_args = ["run", "sh", "-c", "python -m http.server"]
+        buffer = io.StringIO()
+        with tempfile.TemporaryDirectory() as temp_dir, contextlib.redirect_stdout(buffer):
+            code = run_dev_with_reload(uv_args, [Path(temp_dir)], watchfiles_module=None)
+
+        self.assertEqual(code, 0)
+        run_uv.assert_called_once_with(uv_args)
+        self.assertIn("watchfiles", buffer.getvalue())
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_resolve_dev_provider_prefers_openai_then_anthropic_then_ollama(self) -> None:
+        from vex.cli import resolve_dev_provider
+
+        self.assertEqual(resolve_dev_provider({"OPENAI_API_KEY": "sk-x"}), "openai")
+        self.assertEqual(
+            resolve_dev_provider({"ANTHROPIC_API_KEY": "sk-ant-x"}),
+            "anthropic",
+        )
+        self.assertEqual(
+            resolve_dev_provider(
+                {"OPENAI_API_KEY": "sk-x", "ANTHROPIC_API_KEY": "sk-ant-x"}
+            ),
+            "openai",
+        )
+        self.assertEqual(resolve_dev_provider({}), "ollama")
 
     @patch("vex.cli.uv_bin", return_value="uv")
     @patch("vex.cli.run_command", return_value=0)


### PR DESCRIPTION
## Summary

Turn `vex dev` from a thin `[tool.vex.scripts].dev` passthrough into the first real iteration of the dev loop described in `README.md` and `docs/architecture.md`.

Closes part of #8 (trace tail intentionally deferred — see https://github.com/peaktwilight/vex/issues/8#issuecomment-4269279438).

## What this PR does

- **Watchfiles hot reload.** Watches `src/`, any `[tool.vex.dev].watch` paths in `pyproject.toml`, and any repeated `--watch <path>` flags. On change, SIGTERM -> 3s grace -> SIGKILL -> respawn.
- **Optional `watchfiles` dep.** Import is lazy; if the module isn't installed, `vex dev` prints a one-line explainer and falls back to running once (equivalent to `--no-reload`) instead of crashing.
- **Provider banner.** On start, resolves the same provider logic as the scaffolded `settings.py` (`OPENAI_API_KEY` -> openai, `ANTHROPIC_API_KEY` -> anthropic, else ollama) and prints one line like `[vex dev] provider=openai`. When falling through to ollama and `ollama` is not on `PATH`, prints an install pointer to `https://ollama.com`.
- **New flags:**
  - `--no-reload` — skip watchfiles, run once
  - `--watch <path>` (repeatable) — additional watch paths
  - `--provider-check / --no-provider-check` — toggle banner
- **Flag extraction.** Dev-specific flags are consumed from `argv` in `main()` using the same pattern as `vex run --sandbox`, so unknown flags still pass through to the user's dev script.
- **Existing behaviour preserved.** `vex dev` with a `[tool.vex.scripts].dev` alias still runs that script via `uv run sh -c <cmd>` — just with the provider banner and reload wrapped around it.

## Scope

In:
- watchfiles-driven restart loop with graceful child shutdown
- provider detection + banner + friendly ollama-missing pointer
- the three flags above
- unit tests for the five behaviours the issue brief asked for, plus a reload-config-builder test and a fallback-when-watchfiles-missing test

Out (deliberately):
- **Inline trace tail.** The issue calls for streaming LLM calls with latency / token counts to the terminal. That needs an agreed trace file format first (where does the agent write traces, what schema, which runtime owns it — vex-ai-runtime or pydantic-ai hooks?). Parking it here keeps this PR mergeable and lets us design the trace contract separately. Full reasoning in https://github.com/peaktwilight/vex/issues/8#issuecomment-4269279438.

## Non-scope

- No TUI library (no `rich`/`textual`). Plain ANSI lines.
- No new dependencies forced on users — `watchfiles` stays optional.
- No changes to other commands.

## Design notes worth a second look

- **Flag parsing pattern.** `vex dev` uses `nargs=REMAINDER` for the script args, which eats dashed tokens. To keep `--no-reload`, `--watch`, `--provider-check/--no-provider-check` usable, `main()` now strips those leading tokens off `raw_argv` before putting the rest into `args.args` — exactly the shape `vex run --sandbox` already uses. If you'd rather have a dedicated parsing helper that both commands share, happy to refactor in a follow-up.
- **`[tool.vex.dev].watch` schema.** Accepts a list of strings only. Easiest thing that could work; no sub-keys yet. If we want glob patterns or per-path options later, the config surface can grow without breaking this.
- **Default watch root is `src/`** (if it exists). Projects scaffolded by `vex init agent` always have `src/<pkg>/`, so the default is correct for our own templates without needing extra config.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — 52 tests pass (42 existing + 10 new around dev)
- [x] Manual smoke: `vex dev --no-reload` with `[tool.vex.scripts].dev` still shells out through `uv run sh -c`
- [x] Manual smoke: banner prints with `OPENAI_API_KEY` set -> `provider=openai`
- [x] Manual smoke: `--no-provider-check` suppresses the banner
- [x] Manual smoke: `--no-reload` disables watchfiles
- [ ] End-to-end restart-on-change check in a real project (hard to unit-test; covered by the existing unit test on the reload-path fallback)

none