### PR TITLE
chore: drop unused variable in _append_ai_provider_checks

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -536,10 +536,6 @@ def _append_ai_provider_checks(root: Path, lines: list[str]) -> int:
             if key and key.isupper():
                 declared.append(key)
         expected_provider_keys = [k for k in declared if k.endswith("_API_KEY")]
-        missing = [
-            k for k in expected_provider_keys
-            if not os.environ.get(k) and not any(k == env for env, _ in _HOSTED_PROVIDER_KEYS if os.environ.get(env))
-        ]
         all_missing = all(not os.environ.get(k) for k in expected_provider_keys)
         if expected_provider_keys and all_missing and not ollama_on_path:
             lines.append(


### PR DESCRIPTION
Dead-code cleanup flagged by the dev-TUI subagent's review of #15.

The local `missing` list in `_append_ai_provider_checks` was computed but never referenced; only `all_missing` is used in the branching logic below. Safe removal — no behavior change.

## Test plan
- [x] 62/62 tests pass on `PYTHONPATH=src python3 -m unittest tests.test_cli`