### PR TITLE
fix: normalize scaffolded requires-python and flip package-mode (#21)

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -53,6 +53,10 @@ DEFAULT_SCRIPT_COMMANDS = {
 
 PASSTHROUGH_COMMANDS = {"run", "test", "lint", "format", "typecheck", "dev"}
 AI_TEMPLATES = {"agent", "inference-api"}
+# Python floor used by scaffolded projects when the user does not pass --python.
+# Kept conservative so fresh projects stay portable across common developer machines.
+DEFAULT_SCAFFOLD_PYTHON = "3.12"
+DEFAULT_SCAFFOLD_REQUIRES_PYTHON = ">=3.11"
 VEX_MODEL_SCHEMA_VERSION = "v1"
 VEX_RUNTIME_NAME = "vex-ai-runtime"
 VEX_MODEL_SCHEMA_ID = "vex-model/v1"
@@ -742,8 +746,15 @@ def init_project_dir(path_arg: str | None) -> Path:
     return project_root()
 
 
-def build_init_args(args: argparse.Namespace, init_path: str | None) -> tuple[list[str], Path, bool]:
-    package_mode = bool(args.lib)
+def build_init_args(
+    args: argparse.Namespace,
+    init_path: str | None,
+    template: str | None = None,
+) -> tuple[list[str], Path, bool]:
+    # Agent / inference-api templates install as editable packages so their
+    # scaffolded `python -m <pkg>.main` dev commands resolve without PYTHONPATH.
+    ai_template = template in AI_TEMPLATES
+    package_mode = bool(args.lib) or ai_template
     uv_args = ["init"]
 
     if init_path:
@@ -752,15 +763,54 @@ def build_init_args(args: argparse.Namespace, init_path: str | None) -> tuple[li
         uv_args.extend(["--name", args.name])
     if args.python:
         uv_args.extend(["--python", args.python])
+    else:
+        # Avoid inheriting whatever Python is newest on the scaffolder's
+        # machine (e.g. 3.14) which makes the generated project unusable on
+        # typical developer machines. The floor is normalized again post-init.
+        uv_args.extend(["--python", DEFAULT_SCAFFOLD_PYTHON])
 
     uv_args.extend(["--vcs", "none", "--no-workspace"])
 
     if args.lib:
         uv_args.extend(["--lib", "--package", "--build-backend", "hatch"])
+    elif ai_template:
+        uv_args.extend(["--package", "--build-backend", "hatch"])
     else:
         uv_args.extend(["--app", "--no-package"])
 
     return uv_args, init_project_dir(init_path), package_mode
+
+
+def normalize_python_pin(root: Path, requested: str | None) -> None:
+    """Pin scaffolded projects to a portable Python floor.
+
+    `uv init` inherits the newest interpreter available on the scaffolder's
+    machine, which produces unusable `requires-python` pins (e.g. `>=3.14`)
+    when the user did not explicitly request a version. Rewrite both the
+    pyproject constraint and `.python-version` to stable defaults when the
+    user did not pass `--python`.
+    """
+    if requested:
+        return
+
+    pyproject_path = root / "pyproject.toml"
+    if pyproject_path.exists():
+        content = pyproject_path.read_text(encoding="utf-8")
+        new_content = re.sub(
+            r'^requires-python\s*=\s*"[^"]*"',
+            f'requires-python = "{DEFAULT_SCAFFOLD_REQUIRES_PYTHON}"',
+            content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if new_content != content:
+            pyproject_path.write_text(new_content, encoding="utf-8")
+
+    python_version_path = root / ".python-version"
+    if python_version_path.exists():
+        python_version_path.write_text(
+            f"{DEFAULT_SCAFFOLD_PYTHON}\n", encoding="utf-8"
+        )
 
 
 def write_file(path: Path, content: str) -> None:
@@ -2384,9 +2434,10 @@ def handle_init(args: argparse.Namespace) -> int:
         print(str(exc))
         return 2
 
-    uv_args, root, package_mode = build_init_args(args, init_path)
+    uv_args, root, package_mode = build_init_args(args, init_path, template=template)
     code = run_uv(uv_args)
     if code == 0:
+        normalize_python_pin(root, args.python)
         package_name = default_package_name(root, args.name)
         append_vex_config(root, package_mode=package_mode, template=template, package_name=package_name)
         scaffold_ai_template(root, template=template, package_name=package_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,6 +398,7 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         self.assertIn('template = "agent"', pyproject_text)
+        self.assertIn("package-mode = true", pyproject_text)
         self.assertIn('dev = "python -m support_agent.main"', pyproject_text)
         self.assertIn('benchmark = "python -m support_agent.benchmark"', pyproject_text)
         self.assertIn('eval = "python evals/run_eval.py --input {input}"', pyproject_text)
@@ -433,6 +434,23 @@ class CliTests(unittest.TestCase):
         for line in case_lines:
             parsed = _json.loads(line)
             self.assertIn("input", parsed)
+
+    def test_init_agent_produces_portable_python_floor(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(["init", "agent", "portable-agent"])
+            finally:
+                os.chdir(original_cwd)
+
+            root = Path(temp_dir) / "portable-agent"
+            pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+            python_version = (root / ".python-version").read_text(encoding="utf-8").strip()
+
+        self.assertEqual(code, 0)
+        self.assertIn('requires-python = ">=3.11"', pyproject)
+        self.assertEqual(python_version, "3.12")
 
     def test_init_inference_api_creates_template_files(self) -> None:
         original_cwd = os.getcwd()


### PR DESCRIPTION
## Summary

Closes #21.

Two bugs in `vex init` made freshly scaffolded projects unusable on typical dev machines:

### Bug 1: `requires-python` pinned to latest Python

**Before:** running `vex init agent demo` on a machine where 3.14 is the newest Python produced `requires-python = ">=3.14"` and `.python-version = 3.14`. Any collaborator running `uv sync --python 3.12` then hit an interpreter mismatch.

**After:** `vex init` now passes `--python 3.12` to `uv init` by default, then post-processes the generated project in `normalize_python_pin` to pin `requires-python = ">=3.11"` and `.python-version = 3.12`. The existing `--python <ver>` flag still overrides both (normalization is skipped when the user was explicit).

### Bug 2: `package-mode = false` + `python -m <pkg>.main`

**Before:** agent / inference-api templates scaffolded with `package-mode = false` and `[project]` configured as `--app --no-package`, but their `[tool.vex.scripts].dev = "python -m <pkg>.main"` required the package to be importable. Running `vex dev` (or `uv run python -m <pkg>.main`) failed with `ModuleNotFoundError` because `src/` isn't on `sys.path` and the package was never installed.

**After:** agent / inference-api templates now scaffold with `package-mode = true`, using `--package --build-backend hatch`. `uv sync` installs the package in editable mode, so `python -m <pkg>.main` resolves naturally. Non-template (generic) `vex init` inits keep their previous `--app --no-package` default, and `--lib` continues to produce a library layout unchanged.

## Test plan

- [x] Existing tests still pass: `PYTHONPATH=src python3 -m unittest tests.test_cli` (63 passed, including the new case).
- [x] Extended `test_init_agent_creates_template_files` to assert `package-mode = true`.
- [x] New `test_init_agent_produces_portable_python_floor` asserts `requires-python = ">=3.11"` and `.python-version = 3.12`.
- [x] E2E verified on a machine with 3.14 as newest Python: `vex init agent demo` produces a portable pin and `uv sync --extra agent && uv run python -m demo.main` now imports the package (hits the real OpenAI call path instead of `ModuleNotFoundError`).
- [x] `vex init agent foo --python 3.13` still honors the override (`requires-python = ">=3.13"`, `.python-version = 3.13`).

## Tradeoffs

- Hard-coded Python floor (`3.11` / `3.12`) lives in `src/vex/cli.py` as two module constants (`DEFAULT_SCAFFOLD_PYTHON`, `DEFAULT_SCAFFOLD_REQUIRES_PYTHON`). When we want to bump the floor we touch one place.
- `--app` flag is preserved for generic (non-template) inits to keep the existing `test_init_appends_vex_config` assertion (`package-mode = false`) valid; flipping that too would be a wider UX change. Agent / inference-api templates ignore `--app`/`--lib` and always use the package layout, because that's the only config where the generated `python -m <pkg>.main` script actually works.

none