### PR TITLE
feat: scaffold Logfire + OTel observability hook and doctor check

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -462,6 +462,7 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
                     )
 
         issues += _append_ai_provider_checks(root, lines)
+        _append_observability_checks(lines)
         issues += _append_eval_dataset_checks(root, lines)
         issues += _append_deploy_env_checks(root, lines)
 
@@ -550,6 +551,48 @@ def _append_ai_provider_checks(root: Path, lines: list[str]) -> int:
             )
 
     return issues
+
+
+def _append_observability_checks(lines: list[str]) -> None:
+    """Report observability configuration (soft warn — observability is optional)."""
+    logfire_token = os.environ.get("LOGFIRE_TOKEN")
+    otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+    if logfire_token:
+        lines.append("OK  observability: logfire")
+        return
+
+    if otel_endpoint:
+        host = _otel_endpoint_host(otel_endpoint)
+        lines.append(f"OK  observability: otel endpoint={host}")
+        return
+
+    lines.append(
+        "WARN no observability configured "
+        "(set LOGFIRE_TOKEN or OTEL_EXPORTER_OTLP_ENDPOINT)"
+    )
+
+
+def _otel_endpoint_host(endpoint: str) -> str:
+    """Strip path and credentials from an OTLP endpoint URL, returning host[:port]."""
+    from urllib.parse import urlparse
+
+    raw = endpoint.strip()
+    parsed = urlparse(raw if "://" in raw else f"//{raw}", scheme="")
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    if not host:
+        # Fall back to stripping trailing path/query/fragment manually for values
+        # like "collector:4317" that urlparse may not decompose reliably.
+        cleaned = raw.split("?", 1)[0].split("#", 1)[0]
+        if "://" in cleaned:
+            cleaned = cleaned.split("://", 1)[1]
+        if "@" in cleaned:
+            cleaned = cleaned.split("@", 1)[1]
+        cleaned = cleaned.split("/", 1)[0]
+        host = cleaned
+    return host
 
 
 def _append_eval_dataset_checks(root: Path, lines: list[str]) -> int:
@@ -682,6 +725,9 @@ def append_vex_config(root: Path, package_mode: bool, template: str | None, pack
                 "eval = [\n"
                 "  \"deepeval>=0.21\",\n"
                 "  \"ragas>=0.2\",\n"
+                "]\n"
+                "observability = [\n"
+                "  \"logfire>=3.0\",\n"
                 "]\n"
             )
     if template == "inference-api":
@@ -854,7 +900,15 @@ def scaffold_agent_template(root: Path, package_name: str) -> None:
         (
             "from __future__ import annotations\n\n"
             "import asyncio\n"
+            "import os\n"
             "import sys\n\n"
+            "if os.environ.get(\"LOGFIRE_TOKEN\"):\n"
+            "    try:\n"
+            "        import logfire\n\n"
+            "        logfire.configure()\n"
+            "        logfire.instrument_pydantic_ai()\n"
+            "    except ImportError:\n"
+            "        pass\n\n"
             "from .agent import build_agent\n"
             "from .settings import Settings\n\n\n"
             "async def _run(prompt: str) -> str:\n"
@@ -992,7 +1046,11 @@ def scaffold_agent_template(root: Path, package_name: str) -> None:
             "# VEX_OPENAI_MODEL=gpt-4o-mini\n"
             "# VEX_ANTHROPIC_MODEL=claude-3-5-sonnet-latest\n"
             "# VEX_OLLAMA_MODEL=llama3.2\n"
-            "# VEX_OLLAMA_BASE_URL=http://localhost:11434/v1\n"
+            "# VEX_OLLAMA_BASE_URL=http://localhost:11434/v1\n\n"
+            "# Observability (optional)\n"
+            "# LOGFIRE_TOKEN=pylf_v1_...\n"
+            "# OTEL_EXPORTER_OTLP_ENDPOINT=https://your-otel-collector\n"
+            "# OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20...\n"
         ),
     )
     write_file(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -403,6 +403,8 @@ class CliTests(unittest.TestCase):
         self.assertIn('eval = "python evals/run_eval.py --input {input}"', pyproject_text)
         self.assertIn('[project.optional-dependencies]', pyproject_text)
         self.assertIn('"pydantic-ai>=0.0.0"', pyproject_text)
+        self.assertIn('observability = [', pyproject_text)
+        self.assertIn('"logfire>=3.0"', pyproject_text)
         self.assertTrue(has_deploy_targets)
         self.assertTrue(has_prompt)
         self.assertTrue(has_dataset)
@@ -415,9 +417,17 @@ class CliTests(unittest.TestCase):
         self.assertIn("resolve_provider", settings_src)
         self.assertIn("ollama", settings_src)
         self.assertIn("build_agent", main_src)
+        self.assertIn('if os.environ.get("LOGFIRE_TOKEN"):', main_src)
+        self.assertIn("import logfire", main_src)
+        self.assertIn("logfire.configure()", main_src)
+        self.assertIn("logfire.instrument_pydantic_ai()", main_src)
+        self.assertIn("except ImportError:", main_src)
         self.assertIn("asyncio.run", eval_src)
         self.assertIn("OPENAI_API_KEY", env_example)
         self.assertIn("VEX_OLLAMA_MODEL", env_example)
+        self.assertIn("LOGFIRE_TOKEN=pylf_v1_...", env_example)
+        self.assertIn("OTEL_EXPORTER_OTLP_ENDPOINT=", env_example)
+        self.assertIn("OTEL_EXPORTER_OTLP_HEADERS=", env_example)
 
         for name, source in [
             ("agent.py", agent_src),
@@ -671,6 +681,131 @@ class CliTests(unittest.TestCase):
         self.assertIn(
             "WARN deploy.targets.toml references unbound env vars: "
             "VEX_DEPLOY_REGION, VEX_IMAGE_REPO",
+            output,
+        )
+
+    @patch.dict(os.environ, {"LOGFIRE_TOKEN": "pylf_v1_fake"}, clear=True)
+    @patch("vex.cli.shutil.which", return_value=None)
+    @patch("vex.cli.sandbox_image_cached", return_value=None)
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_reports_observability_logfire(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+        _which: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("OK  observability: logfire", output)
+        self.assertNotIn("WARN no observability configured", output)
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_EXPORTER_OTLP_ENDPOINT": "https://user:pass@collector.example.com:4318/v1/traces"},
+        clear=True,
+    )
+    @patch("vex.cli.shutil.which", return_value=None)
+    @patch("vex.cli.sandbox_image_cached", return_value=None)
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_reports_observability_otel(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+        _which: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                _code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn("OK  observability: otel endpoint=collector.example.com:4318", output)
+        # Credentials and path must be stripped from the reported host.
+        self.assertNotIn("user:pass", output)
+        self.assertNotIn("/v1/traces", output)
+        self.assertNotIn("WARN no observability configured", output)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-testkey"}, clear=True)
+    @patch("vex.cli.shutil.which", return_value=None)
+    @patch("vex.cli.sandbox_image_cached", return_value=None)
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_warns_no_observability_soft(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+        _which: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "engine" / "vex-ai-runtime"
+            (runtime_root / "schemas").mkdir(parents=True)
+            (runtime_root / "schemas" / "vex-model-schema.json").write_text(
+                '{"schema":"vex-model/v1","schema_version":"v1","runtime":"vex-ai-runtime","engine":"onnxruntime"}\n',
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.env]\npath = \".venv\"\n\n"
+                "[tool.vex.scripts]\n"
+                'dev = "python -m demo.main"\n'
+                'benchmark = "python -m demo.benchmark"\n'
+                'eval = "python evals/run_eval.py --input {input}"\n'
+                'test = "pytest"\n\n'
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            (root / "deploy.targets.toml").write_text(
+                "[profiles.default]\n"
+                'image = "ghcr.io/example/demo"\n',
+                encoding="utf-8",
+            )
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            (root / ".venv").mkdir()
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        # Missing observability is a soft warning — must not cause non-zero exit
+        # (only the provider key is set, and all other AI checks are green).
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "WARN no observability configured "
+            "(set LOGFIRE_TOKEN or OTEL_EXPORTER_OTLP_ENDPOINT)",
             output,
         )
 


### PR DESCRIPTION
## Summary

Closes #24. Gives scaffolded PydanticAI agents a one-env-var path to structured LLM traces, and teaches `vex doctor ai` to report the observability posture without making it a hard requirement.

### Per-change

- **`scaffold_agent_template` / `main.py` template.** Near the top of the rendered file:
  ```python
  if os.environ.get("LOGFIRE_TOKEN"):
      try:
          import logfire
          logfire.configure()
          logfire.instrument_pydantic_ai()
      except ImportError:
          pass
  ```
  Guarded by env var, try-import so a missing dep is a no-op. Running without `LOGFIRE_TOKEN` set is byte-for-byte identical to the previous behaviour.

- **`append_vex_config` extras block.** Adds a new optional extra to the scaffolded `pyproject.toml`:
  ```toml
  observability = [
    "logfire>=3.0",
  ]
  ```
  No change to the core `agent` / `eval` extras. `uv sync --extra observability` opts in.

- **Scaffolded `.env.example`.** Documents the two activation paths:
  ```
  # Observability (optional)
  # LOGFIRE_TOKEN=pylf_v1_...
  # OTEL_EXPORTER_OTLP_ENDPOINT=https://your-otel-collector
  # OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20...
  ```

- **`vex doctor ai` — new `_append_observability_checks` helper.** Prints exactly one line:
  - `OK  observability: logfire` when `LOGFIRE_TOKEN` is set
  - `OK  observability: otel endpoint=<host[:port]>` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set (Logfire wins if both are set)
  - `WARN no observability configured (set LOGFIRE_TOKEN or OTEL_EXPORTER_OTLP_ENDPOINT)` otherwise

- **`_otel_endpoint_host` helper.** `urllib.parse.urlparse`-based host extraction that strips userinfo credentials, path, query, and fragment. Falls back to manual splitting for bare `host:port` values that `urlparse` can't decompose cleanly. Verified on:
  - `https://user:pass@collector.example.com:4318/v1/traces` → `collector.example.com:4318`
  - `http://collector:4317` → `collector:4317`
  - `collector.example.com:4318` → `collector.example.com:4318`
  - `https://otel.example.com/` → `otel.example.com`

### Soft-warn rationale

Observability is genuinely optional for local agent development — requiring a Logfire token or OTel collector to get a clean `vex doctor ai` exit code would punish the "just scaffolded, just started hacking" path. The missing-observability line emits `WARN` so developers see it in the report, but `_append_observability_checks` returns `None` (not an `int`) and never increments `issues`, so it does not gate the command's exit status. This mirrors how other optional affordances surface in the doctor output.

### Out of scope (intentional)

- No Logfire hard dep on the vex CLI
- No OTel spans from the vex CLI itself
- No tracing UI or custom instrumentation
- `inference-api` template untouched — mirror it in a follow-up PR

### Design notes

- `logfire>=3.0` pinned as the minimum; Logfire 3.x is the current stable line and has the `instrument_pydantic_ai()` helper.
- OTel endpoint host parsing lives in `cli.py` rather than a shared utils module — it's three lines of boilerplate around `urlparse` and only one caller needs it.
- When both `LOGFIRE_TOKEN` and `OTEL_EXPORTER_OTLP_ENDPOINT` are set, the logfire line wins (Logfire itself will forward to the OTel exporter if configured, so this is the most accurate single-line summary).

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — all 65 tests pass
- [x] `test_init_agent_creates_template_files` extended to assert the Logfire guard, `import logfire`, `logfire.configure()`, `logfire.instrument_pydantic_ai()`, `except ImportError`, the `observability` extra, and the three new `.env.example` lines
- [x] `test_doctor_ai_reports_observability_logfire` — `LOGFIRE_TOKEN` set, no other env → `OK  observability: logfire`
- [x] `test_doctor_ai_reports_observability_otel` — `OTEL_EXPORTER_OTLP_ENDPOINT=https://user:pass@collector.example.com:4318/v1/traces` → `OK  observability: otel endpoint=collector.example.com:4318`; asserts `user:pass` and `/v1/traces` are not in the output
- [x] `test_doctor_ai_warns_no_observability_soft` — otherwise-green project with no observability env → `WARN no observability configured ...` AND exit code 0 (soft warn)
- [x] Manually verified rendered `main.py`, `.env.example`, and `pyproject.toml`

Closes #24