### PR TITLE
ci: pytest migration, TestModel guardrail, first integration test (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,45 @@ jobs:
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.14"
 
       - name: Run vex unit tests
         run: PYTHONPATH=src python -m unittest discover -s tests
+
+  integration:
+    name: Vex Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.14"
+
+      - name: Cache uv downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install vex + test deps
+        run: uv sync --extra dev
+
+      - name: Run integration tests
+        env:
+          VEX_RUN_INTEGRATION: "1"
+        run: uv run pytest tests/integration -m integration -v
 
   runtime-python-tests:
     name: Runtime Python Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,30 @@ Run only runtime tests:
 make test-runtime
 ```
 
+## Running tests
+
+The vex CLI test suite is written as `unittest.TestCase` classes so it can be
+driven by either runner. Pick whichever is convenient:
+
+```bash
+# Stdlib unittest (no extra deps required)
+python -m unittest discover -s tests
+
+# Pytest (runs the same unittest classes plus anything marker-selected)
+pytest tests/
+
+# Integration tests: opt-in, shell out to real `uv`, ~1-2 minutes locally
+pytest tests/integration -m integration
+# or
+VEX_RUN_INTEGRATION=1 pytest tests/integration -m integration
+```
+
+Integration tests are excluded from the default `pytest tests/` run via the
+`addopts` config in `pyproject.toml` — they require `uv` on `PATH` and are
+gated behind the `integration` marker plus the `VEX_RUN_INTEGRATION=1`
+environment variable to avoid surprising contributors with a multi-minute
+scaffold+sync during a quick unit loop.
+
 ## Architecture Boundary
 
 Keep this separation clear:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,23 @@ dev = [
   "ruff>=0.6",
 ]
 
+[dependency-groups]
+test = [
+  "pytest>=8.0",
+]
+
 [project.scripts]
 vex = "vex.cli:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Integration tests are opt-in. They are excluded from default `pytest tests/`
+# runs and must be selected explicitly with `-m integration` (or by setting
+# VEX_RUN_INTEGRATION=1 in CI).
+addopts = "-m 'not integration'"
+markers = [
+  "integration: end-to-end tests that shell out to uv and the real scaffold (deselect with -m 'not integration')",
+]
 
 [tool.vex]
 managed = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures and guardrails for the vex test suite.
+
+This file is intentionally minimal. It exists so that:
+
+1. Pytest picks up ``tests/`` as a test root and adds it to ``sys.path``.
+2. When ``pydantic-ai`` is installed (e.g. inside a scaffolded agent project's
+   venv), we globally disable real model requests. No test, unit or
+   integration, should ever be able to accidentally hit a live LLM API.
+
+``pydantic-ai`` is NOT a dependency of the vex CLI itself, only of
+scaffolded agent projects, so the import is guarded.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - guardrail, exercised only when pydantic-ai is present
+    import pydantic_ai.models
+
+    pydantic_ai.models.ALLOW_MODEL_REQUESTS = False
+except ImportError:
+    # pydantic-ai isn't installed in minimal test runs (e.g. the vex CLI
+    # unit suite). That's fine - there are no agent objects to protect.
+    pass

--- a/tests/integration/test_scaffold_agent.py
+++ b/tests/integration/test_scaffold_agent.py
@@ -1,0 +1,136 @@
+"""End-to-end scaffold integration test.
+
+This test does the full happy-path a user would run after installing vex:
+
+    $ vex init agent demo
+    $ uv sync --extra agent --python 3.12
+    $ python -c "from demo.agent import build_agent; ..."
+
+It is deliberately an *integration* test: it does NOT mock subprocess or uv.
+Because it really shells out to ``uv`` and resolves the scaffolded project's
+dependency tree, it is gated behind the ``integration`` pytest marker and
+skipped by default. Select it explicitly with:
+
+    pytest tests/integration -m integration
+    # or
+    VEX_RUN_INTEGRATION=1 pytest tests/integration -m integration
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import pytest
+except ImportError:  # pragma: no cover - unit suite runs without pytest installed
+    pytest = None  # type: ignore[assignment]
+
+from vex.cli import main
+
+
+def _integration_marker(cls: type) -> type:
+    """Apply ``@pytest.mark.integration`` when pytest is available.
+
+    Under ``python -m unittest discover -s tests`` pytest may not be installed
+    (the unit job doesn't install the dev extras). In that case we skip the
+    decorator entirely and rely on :data:`RUN_INTEGRATION` to gate execution.
+    """
+
+    if pytest is None:
+        return cls
+    return pytest.mark.integration(cls)
+
+
+RUN_INTEGRATION = os.environ.get("VEX_RUN_INTEGRATION") == "1"
+
+
+@_integration_marker
+@unittest.skipUnless(
+    RUN_INTEGRATION,
+    "integration test opt-in only: set VEX_RUN_INTEGRATION=1 or run with `pytest -m integration`",
+)
+class ScaffoldAgentIntegrationTests(unittest.TestCase):
+    """Verify `vex init agent demo` produces a project that actually syncs and imports."""
+
+    def test_scaffold_syncs_and_build_agent_is_importable(self) -> None:
+        if shutil.which("uv") is None:
+            self.skipTest("uv binary not found on PATH")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project = tmp_path / "demo"
+
+            # 1. Scaffold the agent template via the real CLI entrypoint.
+            original_cwd = Path.cwd()
+            try:
+                os.chdir(tmp_path)
+                exit_code = main(["init", "agent", "demo"])
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(exit_code, 0, "vex init agent demo should succeed")
+            self.assertTrue(
+                (project / "src" / "demo" / "agent.py").exists(),
+                "scaffold must produce src/demo/agent.py",
+            )
+
+            # 2. Materialize the project's venv with the agent extra.
+            sync = subprocess.run(
+                ["uv", "sync", "--extra", "agent", "--python", "3.12"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                timeout=360,
+            )
+            self.assertEqual(
+                sync.returncode,
+                0,
+                f"uv sync failed:\nstdout:\n{sync.stdout}\nstderr:\n{sync.stderr}",
+            )
+
+            venv_python = project / ".venv" / "bin" / "python"
+            self.assertTrue(
+                venv_python.exists(),
+                f"expected venv python at {venv_python}, uv sync output:\n"
+                f"{sync.stdout}\n{sync.stderr}",
+            )
+
+            # 3. Import the scaffolded agent inside the venv and swap in a
+            #    PydanticAI TestModel so the call graph is exercised without
+            #    touching a real LLM.
+            snippet = (
+                "from pydantic_ai.models.test import TestModel;"
+                "from demo.agent import build_agent;"
+                "agent = build_agent();"
+                "agent.override(model=TestModel());"
+                "print('ok')"
+            )
+            result = subprocess.run(
+                [str(venv_python), "-c", snippet],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"import/override failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertIn("ok", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # Allow `python tests/integration/test_scaffold_agent.py` as a manual run,
+    # but do not invoke the integration path under a plain unittest discovery
+    # run by default - require the env var to opt in.
+    if not RUN_INTEGRATION:
+        print("set VEX_RUN_INTEGRATION=1 to run this test", file=sys.stderr)
+        sys.exit(0)
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -249,9 +249,17 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+test = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
+
+[package.metadata.requires-dev]
+test = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary

Closes #25 (CI sprint 1). Three landing pieces:

- **Pytest alongside unittest.** Adds `pytest` as a proper dep-group in `pyproject.toml` with `[tool.pytest.ini_options]` wiring. `pytest tests/` now collects the existing `tests/test_cli.py` unchanged (pytest has native unittest compat), and `python -m unittest discover -s tests` still passes. 62 unit tests run under both runners, 1 integration test is deselected by default.
- **TestModel guardrail in `tests/conftest.py`.** Sets `pydantic_ai.models.ALLOW_MODEL_REQUESTS = False` globally, guarded behind a try/except because `pydantic-ai` is NOT a vex CLI dep - only scaffolded agent projects depend on it. When it is installed (e.g. inside a scaffolded venv), no test can accidentally hit a live LLM.
- **First integration test: `tests/integration/test_scaffold_agent.py`.** Runs `main(["init", "agent", "demo"])` in a tempdir, shells out to real `uv sync --extra agent --python 3.12`, then imports `demo.agent.build_agent` inside the resulting venv and swaps in `pydantic_ai.models.test.TestModel` via `agent.override(...)`. Gated behind the `integration` pytest marker AND `VEX_RUN_INTEGRATION=1` to keep the unit loop fast.
- **`ci.yml`:** `setup-uv@v5` version pinned to `0.5.14` on both the existing `vex-tests` job and the new `integration` job. Integration job has `~/.cache/uv` caching keyed on `uv.lock`, an 8-minute timeout, and runs `uv run pytest tests/integration -m integration -v` with the env var set.
- **`CONTRIBUTING.md`:** Short "Running tests" section covering all three invocations.

## Rationale for scope

Four other PRs (#21 scaffold bugs, #22 README, #23 Inspect AI swap, #24 Logfire) are in flight and each will add tests to `tests/test_cli.py`. This branch was the most conflict-prone, so it was trimmed to be purely **additive**:

- `tests/test_cli.py` is **unmodified** - no rename, no restructuring. Pytest picks it up via its unittest compatibility layer.
- `tests/` -> `tests/unit/` / `tests/integration/` migration is deferred to a follow-up PR once the parallel branches land.
- New files only: `tests/conftest.py`, `tests/integration/__init__.py`, `tests/integration/test_scaffold_agent.py`.
- `ci.yml` gets one new job plus a single `with: version:` pin on the existing job.

## Out of scope for this PR

- `tests/unit/` rename (follow-up)
- Contract tests (real modal / gcloud / docker / uvx promptfoo)
- Full E2E release gate workflow
- macOS matrix
- `dorny/paths-filter` change detection
- Sharded integration runs

## Test plan

- [x] `python -m unittest discover -s tests` - 63 tests, 1 skipped (integration), all pass
- [x] `pytest tests/` - 62 passed, 1 deselected via `addopts = -m 'not integration'`
- [x] `pytest tests/integration -m integration` without env var - 1 skipped cleanly
- [ ] CI `vex-tests` job green
- [ ] CI `integration` job green (real `vex init agent demo` + `uv sync --extra agent` + `TestModel` override)

none