### PR TITLE
docs: refresh roadmap / architecture, add policy, deploy, eval pages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,8 @@
 
 ## Goal
 
-`vex` should unify the Python AI app workflow without inventing a parallel packaging ecosystem.
+`vex` should unify the Python AI app workflow without inventing a parallel
+packaging ecosystem.
 
 It should explicitly build on top of `uv`, not compete with `uv`.
 
@@ -15,6 +16,51 @@ It should explicitly build on top of `uv`, not compete with `uv`.
 5. Optimize for AI app developers first.
 6. Treat runtime choice, policy, and model packaging as first-class workflow concerns.
 
+## Layered Architecture
+
+`vex` is a thin control plane that composes existing tools. Every verb is a
+wrapper; the real work happens in the adapter layer below.
+
+```
+  pyproject.toml  +  deploy.targets.toml       (single source of truth)
+        │
+        ▼
+  src/vex/cli.py                               (control plane)
+  argparse surface, config loading, provider resolution,
+  [tool.vex.scripts] + [tool.vex.policy] + [tool.vex.eval] + [tool.vex.ai]
+        │
+        ▼
+  ┌──────────────┬──────────────┬──────────────┬──────────────────┐
+  │  eval layer  │ deploy layer │ sandbox layer│   runtime layer  │
+  │              │              │              │                  │
+  │  harness     │  docker      │  docker /    │ vex-ai-runtime   │
+  │  promptfoo   │  cloud-run   │  podman      │ (native model    │
+  │  Inspect AI  │  modal       │  execution   │  load + policy)  │
+  │  (intended)  │              │              │                  │
+  └──────────────┴──────────────┴──────────────┴──────────────────┘
+        │
+        ▼
+  composed tools (subprocess calls, no reimplementation)
+  uv · PydanticAI · ollama · promptfoo · Inspect AI (intended)
+  Modal · gcloud / Cloud Run · Docker/Podman · watchfiles
+  Logfire / OTel GenAI (intended) · vex-ai-runtime
+```
+
+Read top-to-bottom: config declares intent, the CLI resolves it, adapters pick
+the right backend, and the actual work is delegated to a mature tool. `vex`
+itself owns no resolver, lockfile, runtime, or eval executor.
+
+Detailed reading per layer:
+
+- Eval layer — see [`eval.md`](eval.md) for adapter precedence, the
+  `vex-eval/v1` schema, and `--min-pass-rate` semantics.
+- Deploy layer — see [`deploy.md`](deploy.md) for `deploy.targets.toml`
+  schema, profile inheritance, env interpolation, and preflight.
+- Sandbox layer — see [`policy.md`](policy.md) for the `[tool.vex.policy]`
+  schema and what `vex run --sandbox` actually enforces.
+- Runtime layer — see [`engine/vex-ai-runtime/`](../engine/vex-ai-runtime/)
+  for the native execution path and packaged artifact validation.
+
 ## Recommended Integration Stack
 
 ### Core Substrate
@@ -26,24 +72,26 @@ It should explicitly build on top of `uv`, not compete with `uv`.
   - command execution
   - build and publish delegation
   - isolated tool execution
+
 ### AI Workflow Layer
 
 - `vex-ai-runtime`
-  - secure packaged model artifacts
+  - secure packaged model artifacts (`vex-model/v1` schema)
   - native inference execution
   - runtime policy enforcement
 - local model runtimes like `ollama`
-  - local development and fallback execution paths
-- eval and benchmark adapters
-  - local-first quality and performance loops
+  - local development and fallback execution paths when no hosted API key is set
+- eval adapters
+  - Python harness (built-in, always available)
+  - promptfoo (opt-in, auto-delegates when `promptfooconfig.yaml` exists)
+  - Inspect AI (intended default, tracked in issue #23)
+- deployment adapters
+  - Docker/OCI, Google Cloud Run, and Modal — all shipped end-to-end with
+    `--apply`/`--run`
+- observability adapters
+  - Logfire / OTel GenAI (intended, tracked in issue #24)
 - `watchfiles`
-  - generic dev reload support for AI apps
-
-### Later Phase
-
-- deployment adapters for Modal, BentoML, Baseten, or OCI-first workflows
-- policy-aware packaging for agent and model artifacts
-- richer local benchmark and eval integrations
+  - generic dev reload support for `vex dev`
 
 ## Non-Goals
 
@@ -55,11 +103,13 @@ It should explicitly build on top of `uv`, not compete with `uv`.
 
 ## Why AI Workflow Is The Better Wedge
 
-`uv` already solved a large part of generic Python workflow. The remaining open space is higher-level and AI-specific:
+`uv` already solved a large part of generic Python workflow. The remaining open
+space is higher-level and AI-specific:
 
 - local-first AI app workflow is still fragmented
 - model packaging and execution policy are not first-class in generic Python tools
 - deployment and runtime choices are still split across many products
 - AI app packaging is not the same thing as Python dependency management
 
-The better wedge for `vex` is an AI-native workflow layer that can later orchestrate `vex-ai-runtime` and other execution backends.
+The better wedge for `vex` is an AI-native workflow layer that can later
+orchestrate `vex-ai-runtime` and other execution backends.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,118 @@
+# Deploy
+
+`vex deploy` ships a vex-managed project to one of three targets — `docker`,
+`cloud-run`, or `modal` — using `deploy.targets.toml` profiles and, where
+needed, a scaffolded config file. Every target supports the same three modes:
+
+- no flag — scaffold only (write the target's config file, print its path)
+- `--apply` — scaffold then apply via the vendor CLI, captures URL output
+- `--run` — scaffold then run locally (docker) or deploy (cloud-run / modal),
+  surfaces the resulting URL
+
+`--apply` and `--run` run `vex deploy check --for <target>` automatically as a
+preflight. Pass `--skip-preflight` to override.
+
+## Targets
+
+### `docker`
+
+- **Scaffold**: none — `docker build` is invoked directly against the project's
+  existing `Dockerfile`.
+- **`--apply`**: no-op; use `--run` for local execution, or add `--push` to
+  push the built image.
+- **`--run`**: `docker build -t <image>:<tag> .` followed by
+  `docker run --rm -p <port>:<port> <image>:<tag>`. Port defaults to `8000`,
+  override via `--port`.
+- **Backends**: `docker` or `podman` (first one found on `PATH`).
+- **Flags**: `--image`, `--tag`, `--push`, `--port`.
+
+### `cloud-run`
+
+- **Scaffold**: `deploy/cloud-run.yaml` (Knative `Service` with the resolved
+  `<image>:<tag>` and a comment recording the target region).
+- **`--apply` / `--run`**: `gcloud builds submit --tag <image>:<tag>` then
+  `gcloud run deploy <service> --image <image>:<tag> --region <region>
+  --format value(status.url) --quiet`. Extra flags are set from the profile
+  when present: `--memory`, `--cpu`, `--min-instances`, `--max-instances`,
+  `--service-account`, and `--allow-unauthenticated` /
+  `--no-allow-unauthenticated`.
+- **URL capture**: the service URL (`*.run.app`) is extracted from stdout /
+  stderr and echoed as `Deployed: <url>`.
+- **Requires**: `gcloud` on `PATH` plus an active project (either
+  `--project` or `GOOGLE_CLOUD_PROJECT` or a `gcloud config` default).
+
+### `modal`
+
+- **Scaffold**: `deploy/modal_app.py` with a minimal `modal.App` and a
+  `fastapi_endpoint`-backed `/healthz` handler so `modal deploy` has something
+  to register.
+- **`--run`**: `modal deploy deploy/modal_app.py` (captured output, prints
+  `Deployed: <url>` once a `*.modal.run` URL appears in the output).
+- **Requires**: `modal` on `PATH`; `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`
+  environment variables (preflight warns when they are missing).
+
+## `deploy.targets.toml` schema
+
+Live under the project root. Profiles are TOML tables; a profile can inherit
+from another using `inherit = "<name>"`. String values are passed through env
+interpolation (`${VAR}` or `${VAR:-fallback}`).
+
+Example — [`examples/support-bot/deploy.targets.toml`](../examples/support-bot/deploy.targets.toml):
+
+```toml
+[profiles.default]
+image = "ghcr.io/example/support-bot"
+tag = "latest"
+service = "support-bot-agent"
+region = "us-central1"
+app_name = "support-bot-agent"
+push = false
+
+[profiles.prod]
+inherit = "default"
+tag = "prod"
+image = "${VEX_IMAGE_REPO:-ghcr.io/example/support-bot}"
+push = true
+```
+
+Common keys:
+
+- `image`, `tag` — used by all three targets
+- `push` — boolean, only honored by docker
+- `service`, `region` — Cloud Run service name and region
+- `project` — optional GCP project override
+- `app_name` — Modal app name
+- `memory`, `cpu`, `min_instances`, `max_instances`, `service_account`,
+  `allow_unauthenticated` — extra Cloud Run `gcloud run deploy` flags
+
+## Preflight semantics
+
+`vex deploy check [--for all|docker|cloud-run|modal]` inspects the local
+environment and reports `OK` / `WARN` per check:
+
+- `uv` on `PATH`
+- profile `image:tag` resolution
+- docker-compatible CLI (for `docker`)
+- `gcloud` CLI and configured project (for `cloud-run`)
+- `modal` CLI and `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` (for `modal`)
+- runtime root detection (`engine/vex-ai-runtime/` or `VEX_AI_RUNTIME_PATH`)
+- presence of `deploy.targets.toml`
+
+Exit code is the number of issues. `--apply` and `--run` call the same
+preflight and abort when issues are found unless `--skip-preflight` is set.
+
+## Override precedence
+
+Order of resolution for every knob (highest wins):
+
+1. **CLI flag** — e.g. `--image`, `--tag`, `--project`, `--port`
+2. **Profile** — the selected `[profiles.<name>]` table, with inheritance
+   resolved and env interpolation applied
+3. **Environment** — only via `${VAR}` interpolation inside profile values,
+   plus `GOOGLE_CLOUD_PROJECT` / `MODAL_TOKEN_*` for preflight
+
+Select a non-default profile with `--profile <name>`.
+
+See also: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md), [`policy.md`](policy.md),
+[`eval.md`](eval.md).

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,0 +1,117 @@
+# Eval
+
+`vex eval` runs dataset-driven checks over the project, emits a normalized
+`vex-eval/v1` JSON report, and can gate CI on a minimum pass rate. There are
+three adapters today and one in flight.
+
+## Adapters
+
+- **harness** — built-in, always available. Executes the configured command
+  under `uv run` for each case in `evals/datasets/cases.jsonl` (with
+  `--per-case`) or once for the whole dataset (default).
+- **promptfoo** — opt-in adapter that shells out to `uvx promptfoo` (or a
+  system `promptfoo` on `PATH`) when a `promptfooconfig.yaml` file is present.
+  Normalizes promptfoo's output into the same `vex-eval/v1` schema. promptfoo
+  is owned by OpenAI as of 2026-03-09; the adapter is stable, but is no longer
+  the intended default.
+- **Inspect AI** — becomes the default once
+  [issue #23](https://github.com/peaktwilight/vex/issues/23) lands. It replaces
+  promptfoo as the recommended adapter for new projects; promptfoo will remain
+  as a supported adapter for existing pipelines.
+
+## Adapter precedence
+
+Resolved in `handle_eval`:
+
+1. **Explicit `--command`** — always uses the built-in harness.
+2. **`--no-promptfoo`** — force the built-in harness even if
+   `promptfooconfig.yaml` exists.
+3. **`[tool.vex.eval].adapter`** — `"harness"`, `"promptfoo"`, or `"auto"`
+   (default). Unknown values fall back to `"auto"`.
+4. **`"auto"` resolution** — delegate to promptfoo when
+   `promptfooconfig.yaml` (or `.yml`) exists at the project root, otherwise
+   use the harness.
+
+Once the Inspect AI adapter lands, the default for freshly scaffolded projects
+becomes `adapter = "inspect"`; existing projects keep whatever is in
+`pyproject.toml` and can migrate on their own schedule.
+
+## `--json` schema
+
+The normalized report is `vex-eval/v1`. Relevant top-level keys:
+
+- `schema` — always `"vex-eval/v1"`
+- `adapter` — `"harness"` or `"promptfoo"` (future: `"inspect"`)
+- `mode` — `"per-case"` or `"promptfoo"` when applicable
+- `command` / `dataset` — what was executed and against what
+- `dataset_case_count`, `passed`, `failed`
+- `pass_rate` — percentage of cases that passed (0.0–100.0)
+- `duration_ms` — wall-clock time (harness, single-shot mode)
+- `results` — per-case array with `input`, `exit_code`, `passed`,
+  `expect_contains`, `expect_exact`, `expect_json_path`, `expect_json_equals`,
+  plus the `contains_ok` / `exact_ok` / `json_path_ok` gate flags and truncated
+  `stdout` / `stderr` snippets
+
+Use `--json` to print the report to stdout (the human summary is suppressed).
+The report is also written to `--out` (default `artifacts/evals/latest.json`).
+
+## `--min-pass-rate` semantics
+
+`--min-pass-rate <fraction>` accepts a value in `[0.0, 1.0]`. Compares against
+`pass_rate / 100` and sets the exit code to non-zero when the threshold is
+missed, even if every case exited cleanly. The default threshold comes from
+`[tool.vex.eval].min_pass_rate` in `pyproject.toml`:
+
+```toml
+[tool.vex.eval]
+adapter = "auto"
+min_pass_rate = 0.9
+```
+
+The CLI flag overrides the config value. Absent both, no minimum is enforced.
+
+## Authoring `evals/datasets/cases.jsonl`
+
+One JSON object per line. Fields supported by `run_eval_per_case_harness`:
+
+- `input` (string) — substituted into the command. When the command contains
+  `{input}`, it replaces the literal token; otherwise the input is appended as
+  a shell-quoted argument.
+- `expect_contains` (string) — passes when the substring appears in stdout.
+- `expect_exact` (string) — passes when `stdout.strip()` equals the value.
+- `expect_json_path` (dot path string, e.g. `"result.status"`) — parses stdout
+  as JSON and walks the path.
+- `expect_json_equals` (any JSON value) — combined with `expect_json_path`,
+  asserts that the value at the path equals this value.
+
+A case passes when the command exits 0 *and* every specified expectation
+holds. Omit a field to skip its check.
+
+Minimal dataset:
+
+```jsonl
+{"input": "how long do refunds take?", "expect_contains": "5 business days"}
+{"input": "ping", "expect_contains": "ping"}
+{"input": "status", "expect_json_path": "result.status", "expect_json_equals": "ok"}
+```
+
+## CI snippet
+
+Gate CI on the promptfoo adapter emitting 90 %+ pass rate and capture the
+normalized report:
+
+```bash
+vex eval --adapter promptfoo --json --min-pass-rate 0.9 > results.json
+```
+
+`--adapter` is the forthcoming surface for adapter selection; today the same
+effect is achieved via `[tool.vex.eval].adapter = "promptfoo"` plus the
+existing `--json` and `--min-pass-rate` flags:
+
+```bash
+vex eval --json --min-pass-rate 0.9 > results.json
+```
+
+See also: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md), [`deploy.md`](deploy.md),
+[`policy.md`](policy.md).

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,0 +1,138 @@
+# Policy and Sandbox
+
+`vex` treats execution policy as a first-class workflow concern. Policy lives
+in `pyproject.toml` under `[tool.vex.policy]`, is enforced by
+`vex run --sandbox`, and shows up in `vex doctor ai` and deploy preflight.
+
+## `[tool.vex.policy]` schema
+
+Scaffolded defaults from `vex init`:
+
+```toml
+[tool.vex.policy]
+sandbox = true
+network = "deny"
+filesystem = "project"
+sandbox_backend = "auto"
+sandbox_image = "python:3.12-slim"
+sandbox_memory_mb = 1024
+sandbox_pids_limit = 128
+unsafe_fallback = false
+```
+
+Keys:
+
+- `sandbox` (`bool`) — whether sandboxing is expected. `vex doctor ai` checks
+  backend availability only when this is `true`.
+- `network` (`"deny"` | `"allow"`) — translates into the container `--network`
+  flag. `deny` maps to `--network none`, anything else maps to `--network bridge`.
+- `filesystem` (`"project"`) — intent marker for the project-scoped bind mount
+  (currently `{root}:/workspace:ro`).
+- `sandbox_backend` (`"auto"` | `"docker"` | `"podman"`) — `auto` prefers
+  `podman` if present, falls back to `docker`, otherwise reports `none`.
+- `sandbox_image` (`str`) — container image for `vex run --sandbox`. Must be
+  pre-pulled; `vex doctor ai` warns when the image is not cached locally and
+  prints the exact `<backend> pull <image>` command to fix it.
+- `sandbox_memory_mb` (`int`) — hard memory cap, passed as `--memory <N>m`.
+- `sandbox_pids_limit` (`int`) — max PIDs inside the sandbox, passed as
+  `--pids-limit <N>`.
+- `unsafe_fallback` (`bool`) — when no sandbox backend is available and this is
+  `true`, `vex run --sandbox` prints a warning and runs the command unsandboxed
+  instead of exiting with code 2.
+
+## What `vex run --sandbox` actually enforces
+
+Ground truth is `run_sandboxed` in `src/vex/cli.py`. Every invocation runs:
+
+```
+<backend> run --rm
+  --network <none|bridge>       # from policy.network
+  --memory <N>m                 # from policy.sandbox_memory_mb
+  --pids-limit <N>              # from policy.sandbox_pids_limit
+  --read-only
+  --cap-drop ALL
+  --security-opt no-new-privileges
+  -v <project_root>:/workspace:ro
+  -w /workspace
+  <sandbox_image>
+  sh -c <command>
+```
+
+Read-only rootfs, all Linux capabilities dropped, no-new-privileges, project
+directory mounted read-only. Network is denied by default and must be
+explicitly opted into via `network = "allow"`.
+
+## Docker vs Podman detection
+
+`sandbox_backend = "auto"` (the default) resolves via `shutil.which`:
+
+1. Prefer `podman` if it's on `PATH`.
+2. Fall back to `docker`.
+3. Otherwise return `none`.
+
+Pin explicitly with `sandbox_backend = "docker"` or `sandbox_backend = "podman"`
+to override the preference, for example in CI environments where both are
+installed.
+
+## Escape hatches
+
+- `unsafe_fallback = true` — run unsandboxed when no backend is available
+  (a warning is printed, but the command still runs).
+- `vex policy set <key> <value>` — write an override to `.vex/policy.json` that
+  layers on top of the `[tool.vex.policy]` block without editing
+  `pyproject.toml`. Useful for per-developer local tweaks and CI toggles. Pair
+  with `vex policy unset <key>` to remove the override.
+- Drop `--sandbox` from `vex run` to use the plain managed environment.
+
+## Example policies
+
+Agent with a hosted LLM call (needs network):
+
+```toml
+[tool.vex.policy]
+sandbox = true
+network = "allow"
+filesystem = "project"
+sandbox_backend = "docker"
+sandbox_image = "python:3.12-slim"
+sandbox_memory_mb = 2048
+sandbox_pids_limit = 256
+```
+
+Eval harness over a local dataset (fully offline):
+
+```toml
+[tool.vex.policy]
+sandbox = true
+network = "deny"
+filesystem = "project"
+sandbox_memory_mb = 1024
+sandbox_pids_limit = 128
+```
+
+Inference API packaged against `vex-ai-runtime` (tight caps, no network):
+
+```toml
+[tool.vex.policy]
+sandbox = true
+network = "deny"
+filesystem = "project"
+sandbox_backend = "podman"
+sandbox_image = "python:3.12-slim"
+sandbox_memory_mb = 512
+sandbox_pids_limit = 64
+unsafe_fallback = false
+```
+
+## Relationship to `vex-ai-runtime`
+
+`vex run --sandbox` is container-level isolation. For the *native* execution
+angle — signed model artifacts, schema validation, and runtime-enforced
+policies on the inference path — see
+[`engine/vex-ai-runtime/`](../engine/vex-ai-runtime/). The two layers compose:
+`vex` keeps development-time policy honest via containers, and
+`vex-ai-runtime` keeps the production inference path honest via the
+`vex-model/v1` manifest contract.
+
+See also: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md), [`deploy.md`](deploy.md).

--- a/docs/product-boundary.md
+++ b/docs/product-boundary.md
@@ -47,7 +47,9 @@ Those are already strong enough that competing there weakens the product story.
 - `uv` for package/env management
 - `ollama` for local model runtime where useful
 - agent frameworks like `PydanticAI` or `LangGraph`
-- eval tools like `promptfoo` or hosted observability platforms
+- eval tools like `Inspect AI` (intended default), `promptfoo`, or hosted
+  observability platforms
+- observability adapters like `Logfire` / OTel GenAI
 - deployment targets like Modal, BentoML, Baseten, or custom containers
 
 ## Recommended Domain Defaults (MVP)
@@ -57,11 +59,18 @@ Those are already strong enough that competing there weakens the product story.
 - **Scaffolding: inference-api**
   - `FastAPI` + `uvicorn` with typed schemas
 - **Benchmark and eval**
-  - Python-native harness first, then adapters for `deepeval` and `ragas`
+  - Inspect AI by default, promptfoo as opt-in adapter, Python harness as
+    fallback (see [`eval.md`](eval.md) for adapter precedence)
 - **Sandboxing**
   - container sandbox backend for local development, network denied by default
+    (see [`policy.md`](policy.md) for the full `[tool.vex.policy]` schema)
 - **Deployment adapters**
-  - Docker/OCI first, then Cloud Run and Modal as early managed targets
+  - Docker/OCI, Cloud Run, and Modal are all shipped with
+    `vex deploy <target> --apply|--run` (see [`deploy.md`](deploy.md) for
+    target-specific behavior and `deploy.targets.toml`)
+- **Observability**
+  - Logfire / OTel GenAI are the intended adapters so traces from
+    `vex dev` and production inference stay on a shared schema
 
 These defaults are intentionally pragmatic and local-first.
 
@@ -74,17 +83,23 @@ During rapid iteration, a monorepo is recommended:
 
 This keeps schema, packaging, and compatibility changes synchronized.
 
-Long term, the components can still be versioned and released independently. The product boundary stays the same even if source control topology changes.
+Long term, the components can still be versioned and released independently.
+The product boundary stays the same even if source control topology changes.
 
-## Recommended Command Direction
+## Command Surface
+
+AI-native workflow commands that give `vex` a story distinct from generic
+Python tooling:
 
 - `vex init agent`
 - `vex init inference-api`
 - `vex dev`
 - `vex benchmark`
-- `vex policy`
+- `vex eval` (see [`eval.md`](eval.md))
+- `vex policy` (see [`policy.md`](policy.md))
 - `vex package-model`
+- `vex deploy` (see [`deploy.md`](deploy.md))
+- `vex deploy check`
+- `vex schema validate-model`
 - `vex run --sandbox`
 - `vex doctor ai`
-
-These commands give `vex` a story that is distinct from generic Python tooling.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,55 +1,93 @@
 # Roadmap
 
-## Current Prototype
+`vex` is an AI workflow layer that rides on top of `uv`. The roadmap is split
+into three buckets: what's **Shipped** and verified by the test suite, what's
+**Next** on the path to v1, and what's **Later** (still in scope, but not the
+current focus).
 
-- `vex init`
-- `vex add`
-- `vex remove`
-- `vex sync`
-- `vex lock`
-- `vex run`
-- `vex test`
-- `vex lint`
-- `vex format`
-- `vex typecheck`
-- `vex doctor`
+Paired reading: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md),
+[`policy.md`](policy.md), [`deploy.md`](deploy.md), [`eval.md`](eval.md).
+
+## Shipped
+
+Generic `uv` passthroughs — these are bootstrap plumbing so a vex project stays
+a normal Python project, not the long-term moat:
+
+- `vex init`, `vex add`, `vex remove`, `vex sync`, `vex lock`
+- `vex run`, `vex test`, `vex lint`, `vex format`, `vex typecheck`
+- `vex doctor`, `vex build`, `vex publish`
 - `vex python install|pin|list|path|uninstall`
-- `vex build`
-- `vex publish`
 - `vex tool run|install|list|upgrade|uninstall`
 
-These commands are useful bootstrap plumbing because they let `vex` ride on top of `uv`, but they are not the long-term moat.
+AI-native workflow (the actual product):
 
-## Product Direction
+- `vex init agent` — PydanticAI agent scaffold with `agent.py`, `settings.py`
+  (openai / anthropic / ollama auto-resolution), `eval.py`, seed dataset,
+  `.env.example`, `deploy.targets.toml` with `default` and `prod` profiles
+- `vex init inference-api` — FastAPI + uvicorn scaffold with typed schemas
+- `vex dev` — watchfiles-based hot reload plus a provider banner that reports
+  which model backend (hosted or ollama fallback) will be used
+- `vex benchmark` — warmup-aware harness with JSON output
+- `vex eval` — dataset-driven checks with `--json`, `--min-pass-rate`, and a
+  promptfoo adapter that auto-delegates when `promptfooconfig.yaml` is present
+- `vex policy list|get|set|unset` — read and override `[tool.vex.policy]`
+- `vex package-model` — versioned manifest with compatibility metadata for
+  `vex-ai-runtime`
+- `vex deploy docker|cloud-run|modal` — scaffold and end-to-end ship. `--apply`
+  and `--run` drive real subprocess calls (`docker build`, `gcloud builds
+  submit` + `gcloud run deploy`, `modal deploy`) and surface the deployed URL.
+  Supports profile inheritance (`inherit = "default"`) and env interpolation
+  (`${VEX_IMAGE_REPO}`)
+- `vex deploy check [--for all|docker|cloud-run|modal]` — preflight readiness
+  for each target, also runs automatically before `--apply`/`--run`
+- `vex schema validate-model` — verify a packaged artifact against the shared
+  `vex-model/v1` schema
+- `vex run --sandbox` — Docker/Podman-backed execution with `--cap-drop ALL`,
+  `--network none`, read-only rootfs, memory and pids caps,
+  `no-new-privileges`
+- `vex doctor ai` — 13-check AI readiness report (sandbox backend, schema,
+  provider creds, eval dataset shape, deploy env vars, runtime path, etc.)
 
-- `vex init agent`
-- `vex init inference-api`
-- `vex dev`
-- `vex benchmark`
-- `vex eval`
-- `vex policy`
-- `vex package-model`
-- `vex deploy`
-- `vex deploy check`
-- `vex schema validate-model`
-- `vex run --sandbox`
-- `vex doctor ai`
+## Next
+
+On the path to v1:
+
+- `vex eval --policy` — treat `[tool.vex.policy]` (or a named policy block) as
+  a CI gate so evals fail closed on policy violations, not just quality regressions
+- `vex deploy --policy-gate` — block `--apply`/`--run` when policy preconditions
+  (sandbox, secrets, model signature) are not met
+- Trace tail in `vex dev` — inline spans from the agent / HTTP loop during
+  hot-reload so developers see what the model actually did
+- Inspect AI adapter for `vex eval` — in flight in
+  [issue #23](https://github.com/peaktwilight/vex/issues/23); becomes the new
+  default once it lands
+- Logfire observability hook — in flight in
+  [issue #24](https://github.com/peaktwilight/vex/issues/24); OTel GenAI
+  compatible
+- Contract CI between `vex` and `vex-ai-runtime` so schema and manifest changes
+  stay wired across the two repos
 
 ## Later
 
-- `vex export`
-- `vex shell`
-- `vex cache`
-- basic workspace investigation
+Still in scope but not the current focus:
+
+- `vex export` — render a vex project to a plain uv / Docker project so teams
+  can hand it off without vex
+- `vex shell` — ergonomic drop-in into the managed `.venv` with policy
+  defaults applied
+- `vex cache` — share warmed-up model / tool caches across runs
+- Workspace support — multiple vex-managed projects in one monorepo
 
 ## v1 Direction
 
 - polished AI project templates
 - container-oriented and runtime-aware deployment helpers
-- integration with `vex-ai-runtime`
-- local benchmark and evaluation workflows
+- deep integration with `vex-ai-runtime` (native execution + packaged artifacts)
+- local benchmark and evaluation workflows with CI-gradable output
 - opt-in secure packaging and policy enforcement
-- deployment adapters for Docker/OCI, Cloud Run, and Modal
+- deployment adapters for Docker/OCI, Cloud Run, and Modal (shipped); Inspect
+  AI and Logfire adapters wired in (next)
 
 ## Product Guardrails
 


### PR DESCRIPTION
## Summary

Docs audit in #26 flagged that `docs/roadmap.md` still lists every shipped
feature as future work, `docs/architecture.md` claims Modal / Cloud Run /
Docker adapters are "Later Phase" even though all three shipped end-to-end,
and `docs/product-boundary.md` still orders eval tooling as deepeval / ragas
first. This PR refreshes the three rewrite targets and adds the first three
of the missing reference pages.

### Rewrites

- **`docs/roadmap.md`** — restructured into **Shipped** / **Next** / **Later**.
  Moved `vex init agent`, `vex init inference-api`, `vex dev`, `vex benchmark`,
  `vex eval`, `vex policy`, `vex package-model`, `vex deploy`, `vex deploy
  check`, `vex schema validate-model`, `vex run --sandbox`, and `vex doctor ai`
  out of "Product Direction" into Shipped. Next holds `vex eval --policy`,
  `vex deploy --policy-gate`, trace tail in `vex dev`, the Inspect AI adapter
  (#23), the Logfire hook (#24), and the vex / runtime contract CI. Later keeps
  `vex export`, `vex shell`, `vex cache`, workspace support.
- **`docs/architecture.md`** — added a concrete layered-architecture diagram
  (`pyproject.toml` → `src/vex/cli.py` → adapter layer → composed tools),
  dropped the "Later Phase: deployment adapters for Modal / BentoML / Baseten"
  line, updated the integration stack to name Inspect AI and Logfire as
  intended adapters. MVP Principles and Non-Goals are kept verbatim.
- **`docs/product-boundary.md`** — updated the MVP defaults (eval: Inspect AI
  by default, promptfoo as opt-in, Python harness as fallback), added
  `vex eval`, `vex deploy`, `vex deploy check`, and `vex schema validate-model`
  to a renamed "Command Surface" section, added a Logfire / OTel GenAI
  observability line. The uv / vex / vex-ai-runtime ownership split is
  unchanged.

### New files

- **`docs/policy.md`** — full `[tool.vex.policy]` schema (`sandbox`, `network`,
  `filesystem`, `sandbox_backend`, `sandbox_image`, `sandbox_memory_mb`,
  `sandbox_pids_limit`, `unsafe_fallback`), what `vex run --sandbox` actually
  enforces (ground-truth argv from `run_sandboxed` in `src/vex/cli.py`: `--cap-drop
  ALL`, `--network none`, `--read-only`, `--security-opt no-new-privileges`,
  memory / pids caps), Docker vs Podman detection, escape hatches (including
  `vex policy set`), and example policy blocks for agent / eval / inference
  use cases. Links to `engine/vex-ai-runtime/` for the native-execution angle.
- **`docs/deploy.md`** — per-target guides for docker / cloud-run / modal
  (what `--apply`/`--run` do, what gets scaffolded, what subprocess commands
  actually fire), the `deploy.targets.toml` schema with profile inheritance
  (`inherit = "default"`) and env interpolation (`${VEX_IMAGE_REPO}`),
  preflight semantics for `vex deploy check --for <target>` plus the
  auto-preflight before `--apply`/`--run`, and the CLI / profile / env
  override precedence. Links to `examples/support-bot/deploy.targets.toml`.
- **`docs/eval.md`** — the three adapters (harness, promptfoo, Inspect AI once
  #23 lands), adapter precedence from `handle_eval`, the `vex-eval/v1` report
  schema, `--min-pass-rate` semantics and the `[tool.vex.eval].min_pass_rate`
  default, how to author `evals/datasets/cases.jsonl` (supported fields:
  `input`, `expect_contains`, `expect_exact`, `expect_json_path`,
  `expect_json_equals`), and a small CI snippet.

Each new doc is cross-linked from the rewritten `architecture.md` and
`product-boundary.md`. README is intentionally untouched.

## Out of scope

- `cli-reference.md`, `doctor.md`, `templates.md`, `troubleshooting.md`,
  `faq.md`, `runtime.md`, `release.md` — separate follow-up
- `README.md` — that's #22
- `CONTRIBUTING.md` — no changes
- No code changes

## Test plan

- [ ] All six files render on GitHub without broken headings or code blocks
- [ ] Every cross-link in the three new docs resolves (policy / deploy / eval /
      architecture / product-boundary / `engine/vex-ai-runtime/` /
      `examples/support-bot/deploy.targets.toml`)
- [ ] Every shipped command in the rewritten roadmap matches a subcommand in
      `src/vex/cli.py`
- [ ] Every "Next" item in the rewritten roadmap maps to a filed issue or to a
      specific unshipped flag

Closes #26.