### PR TITLE
feat: vex eval --policy runs adapters under the declared sandbox (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ vex policy list                             # prints the effective contract
 
 `vex deploy` is the same contract, pointed at Modal / Cloud Run / Docker. `vex eval` is the same contract, pointed at a dataset. The policy that makes the agent safe in production is the policy your evals already ran under — one artifact, three execution surfaces.
 
-Near-future: `vex eval --policy` will run every eval case inside the sandbox defined by `[tool.vex.policy]`, and `vex deploy --policy-gate` will refuse to ship an agent whose declared tool surface exceeds its policy budget. Enforcement is shipped today via `vex run --sandbox`; the eval and deploy gates are on the roadmap below.
+`vex eval --policy` runs every eval case inside the sandbox defined by `[tool.vex.policy]`, so a case that would need network egress fails the same way the deployed agent would. Near-future: `vex deploy --policy-gate` will refuse to ship an agent whose declared tool surface exceeds its policy budget. Enforcement is shipped today via `vex run --sandbox` and `vex eval --policy`; the deploy gate is on the roadmap below.
 
 ## Not another `langgraph new`
 
@@ -93,7 +93,7 @@ Policy and sandbox (the contract):
 Eval / deploy / doctor / init:
 
 - `vex eval --command ...` and `vex eval --per-case --command "... {input} ..."` — dataset-driven checks
-- `vex eval` auto-delegates to [Inspect AI](https://inspect.aisi.org.uk/) (default) via `uvx --from inspect-ai inspect` when `inspect.yaml` / `inspect.toml` or `evals/*.inspect.py` is present, with [`promptfoo`](https://www.promptfoo.dev) (opt-in) as a fallback when `promptfooconfig.yaml` is present. Use `--adapter inspect|promptfoo|harness|auto` to override, `--json` for machine-readable output, and `--min-pass-rate 0.9` to gate CI on a fraction of passing cases. Override defaults in `[tool.vex.eval]` (`adapter = "auto"|"inspect"|"promptfoo"|"harness"`, `min_pass_rate = 0.9`). `--no-promptfoo` is kept as a deprecated alias for `--adapter harness`.
+- `vex eval` auto-delegates to [Inspect AI](https://inspect.aisi.org.uk/) (default) via `uvx --from inspect-ai inspect` when `inspect.yaml` / `inspect.toml` or `evals/*.inspect.py` is present, with [`promptfoo`](https://www.promptfoo.dev) (opt-in) as a fallback when `promptfooconfig.yaml` is present. Use `--adapter inspect|promptfoo|harness|auto` to override, `--json` for machine-readable output, `--min-pass-rate 0.9` to gate CI on a fraction of passing cases, and `--policy` to run every adapter inside the `[tool.vex.policy]` sandbox (stamps a `policy` block into the report). Override defaults in `[tool.vex.eval]` (`adapter = "auto"|"inspect"|"promptfoo"|"harness"`, `min_pass_rate = 0.9`). `--no-promptfoo` is kept as a deprecated alias for `--adapter harness`.
 - `vex deploy docker|cloud-run|modal [--apply|--run]` — scaffold + ship end-to-end; `docker --run` builds and runs locally, `cloud-run --apply` runs `gcloud builds submit` then `gcloud run deploy` and echoes the service URL, `modal --run` invokes `modal deploy` and surfaces the `*.modal.run` URL. Profile inheritance (`inherit = "default"`), env interpolation (`${VEX_IMAGE_REPO}`), and Cloud Run profile fields (`project`, `memory`, `cpu`, `min_instances`, `max_instances`, `service_account`, `allow_unauthenticated`). Preflight runs automatically on `--apply`/`--run` (override with `--skip-preflight`)
 - `vex deploy check [--for all|docker|cloud-run|modal]` — preflight
 - `vex doctor ai` — readiness report (uv, pyproject, policy, provider env, ollama reachability, eval dataset shape, deploy profile env vars)
@@ -128,7 +128,6 @@ No API key? `vex` falls back to a local [`ollama`](https://ollama.com) model —
 
 The policy contract turns into a gate, not just a declaration:
 
-- `vex eval --policy` — run every eval case inside the `[tool.vex.policy]` sandbox, so a case that needs network egress fails the same way the deployed agent would
 - `vex deploy --policy-gate` — refuse to ship an agent whose declared tool surface exceeds its policy budget, and re-express the policy as the target's native primitive (Modal sandbox, Cloud Run IAM, Docker cap-drop)
 - Trace tail in `vex dev` — inline LLM / tool-call trace view during the reload loop
 - Inspect AI adapter as the default eval backend (see [issue #23](https://github.com/peaktwilight/vex/issues/23))

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -112,6 +112,49 @@ existing `--json` and `--min-pass-rate` flags:
 vex eval --json --min-pass-rate 0.9 > results.json
 ```
 
+## `--policy` — run evals under the declared sandbox
+
+`vex eval --policy` wraps every adapter (`harness`, `per-case`, `promptfoo`,
+`inspect`) inside the sandbox declared in [`[tool.vex.policy]`](policy.md).
+Uses the same argv shape as `vex run --sandbox`: `--cap-drop ALL`,
+`--read-only`, `--network <none|bridge>`, memory + pids caps, project mounted
+read-only at `/workspace`. Adds a `policy` block to the normalized report
+(schema stays `vex-eval/v1`, additive only):
+
+```json
+{
+  "policy": {
+    "enforced": true,
+    "network": "deny",
+    "filesystem": "project",
+    "sandbox_backend": "docker",
+    "sandbox_image": "python:3.12-slim",
+    "sandbox_memory_mb": 1024,
+    "sandbox_pids_limit": 128,
+    "unsafe_fallback_applied": false
+  }
+}
+```
+
+Hard-fail conditions:
+
+- `[tool.vex.policy].sandbox = false` combined with `--policy` exits `2` with
+  a message pointing at `vex policy set sandbox true --type bool`.
+- No sandbox backend available (no `podman` or `docker` on `PATH`) and
+  `unsafe_fallback = false` exits `2` with a pointer at `vex doctor ai`.
+- `unsafe_fallback = true` + no backend runs the adapter locally, prints a
+  `WARN sandbox backend unavailable; running eval without sandbox enforcement
+  (unsafe_fallback=true)` banner, and stamps `enforced: false,
+  unsafe_fallback_applied: true` in the report.
+
+`promptfoo` and `inspect` adapters shell out via `uvx`; when `--policy` is
+active, the entire `uvx promptfoo ...` / `uvx --from inspect-ai inspect ...`
+invocation runs inside the container. The default `python:3.12-slim` image
+does not bundle `uv`, so the adapter prepends a one-shot
+`command -v uvx >/dev/null 2>&1 || pip install --quiet uv` shim before the
+`uvx` call. A follow-up `vex/sandbox-eval:latest` image will pre-bake `uv`
+and drop the shim (see issue #33 discussion).
+
 See also: [`architecture.md`](architecture.md),
 [`product-boundary.md`](product-boundary.md), [`deploy.md`](deploy.md),
 [`policy.md`](policy.md).

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -124,6 +124,18 @@ sandbox_pids_limit = 64
 unsafe_fallback = false
 ```
 
+## Enforcement surfaces
+
+`[tool.vex.policy]` is enforced wherever vex launches a subprocess that runs
+project code:
+
+- `vex run --sandbox ...` — direct invocation under the container shape
+  described above.
+- `vex eval --policy` — wraps every adapter (`harness`, `per-case`,
+  `promptfoo`, `inspect`) under the same sandbox. See
+  [`docs/eval.md#--policy`](eval.md#--policy--run-evals-under-the-declared-sandbox)
+  for the argv shape, the report snapshot, and the hard-fail conditions.
+
 ## Relationship to `vex-ai-runtime`
 
 `vex run --sandbox` is container-level isolation. For the *native* execution

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -1372,21 +1372,27 @@ def sandbox_backend(policy: dict[str, Any]) -> str:
     return "none"
 
 
-def run_sandboxed(command: str, root: Path, policy: dict[str, Any]) -> int:
+def build_sandbox_argv(
+    command: str, root: Path, policy: dict[str, Any]
+) -> list[str] | None:
+    """Return the sandbox argv for ``command`` under ``policy``.
+
+    Produces the full ``[backend, "run", "--rm", ..., image, "sh", "-c",
+    command]`` invocation used by ``vex run --sandbox`` and ``vex eval
+    --policy``. Returns ``None`` when no sandbox backend is available
+    (``sandbox_backend()`` resolves to ``"none"``); callers decide how to
+    handle fallback (unsafe local execution or hard-fail).
+    """
     backend = sandbox_backend(policy)
     if backend == "none":
-        if bool(policy.get("unsafe_fallback", False)):
-            print("WARN sandbox backend unavailable; using unsafe local execution")
-            return run_command(["sh", "-c", command], cwd=root)
-        print("No sandbox backend available. Install podman or docker, or set policy unsafe_fallback=true")
-        return 2
+        return None
 
     image = str(policy.get("sandbox_image", "python:3.12-slim"))
     network_mode = "none" if str(policy.get("network", "deny")) == "deny" else "bridge"
     memory_mb = int(policy.get("sandbox_memory_mb", 1024))
     pids_limit = int(policy.get("sandbox_pids_limit", 128))
 
-    container_cmd = [
+    return [
         backend,
         "run",
         "--rm",
@@ -1410,7 +1416,67 @@ def run_sandboxed(command: str, root: Path, policy: dict[str, Any]) -> int:
         "-c",
         command,
     ]
+
+
+def run_sandboxed(command: str, root: Path, policy: dict[str, Any]) -> int:
+    container_cmd = build_sandbox_argv(command, root, policy)
+    if container_cmd is None:
+        if bool(policy.get("unsafe_fallback", False)):
+            print("WARN sandbox backend unavailable; using unsafe local execution")
+            return run_command(["sh", "-c", command], cwd=root)
+        print("No sandbox backend available. Install podman or docker, or set policy unsafe_fallback=true")
+        return 2
     return run_command(container_cmd)
+
+
+def policy_snapshot(
+    policy: dict[str, Any], *, enforced: bool, unsafe_fallback_applied: bool
+) -> dict[str, Any]:
+    """Produce the ``policy`` block stamped into ``vex eval --policy`` reports."""
+    return {
+        "enforced": enforced,
+        "network": str(policy.get("network", "deny")),
+        "filesystem": str(policy.get("filesystem", "project")),
+        "sandbox_backend": sandbox_backend(policy),
+        "sandbox_image": str(policy.get("sandbox_image", "python:3.12-slim")),
+        "sandbox_memory_mb": int(policy.get("sandbox_memory_mb", 1024)),
+        "sandbox_pids_limit": int(policy.get("sandbox_pids_limit", 128)),
+        "unsafe_fallback_applied": unsafe_fallback_applied,
+    }
+
+
+def resolve_eval_sandbox(
+    root: Path, policy: dict[str, Any]
+) -> tuple[list[str] | None, bool, int]:
+    """Resolve sandbox argv prefix and fallback state for eval adapters.
+
+    Returns a tuple ``(sandbox_prefix, unsafe_fallback_applied, exit_code)``:
+
+    - If a sandbox backend is available: ``(sandbox_prefix, False, 0)`` where
+      ``sandbox_prefix`` is everything up to and including the image slot (the
+      caller appends ``"sh", "-c", command`` or reuses ``build_sandbox_argv``).
+    - If no backend is available but ``unsafe_fallback = true``: ``(None,
+      True, 0)`` — the caller should run locally.
+    - Otherwise: ``(None, False, 2)`` — hard-fail; caller should surface the
+      message already printed and return the exit code.
+    """
+    backend = sandbox_backend(policy)
+    if backend != "none":
+        # Returning a marker prefix keeps the API aligned with callers that
+        # will call build_sandbox_argv() with their final command string.
+        return [backend], False, 0
+    if bool(policy.get("unsafe_fallback", False)):
+        print(
+            "WARN sandbox backend unavailable; running eval without sandbox "
+            "enforcement (unsafe_fallback=true)"
+        )
+        return None, True, 0
+    print(
+        "vex eval --policy requires a sandbox backend (podman or docker). "
+        "Run 'vex doctor ai' to diagnose, or set "
+        "[tool.vex.policy].unsafe_fallback = true to allow running unsandboxed."
+    )
+    return None, False, 2
 
 
 def benchmark_shell_command(root: Path, explicit_command: str | None, extra_args: Sequence[str]) -> str:
@@ -1484,6 +1550,23 @@ def _emit_eval_report(report: dict[str, Any], out_path: Path, emit_json: bool) -
     out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     if emit_json:
         print(json.dumps(report))
+
+
+def _stamp_policy_snapshot(
+    report: dict[str, Any],
+    *,
+    policy: dict[str, Any] | None,
+    enforced: bool,
+    unsafe_fallback_applied: bool,
+) -> None:
+    """Attach a ``policy`` block to ``report`` in place when policy is active."""
+    if policy is None:
+        return
+    report["policy"] = policy_snapshot(
+        policy,
+        enforced=enforced,
+        unsafe_fallback_applied=unsafe_fallback_applied,
+    )
 
 
 def _apply_min_pass_rate(report: dict[str, Any], threshold: float | None, exit_code: int) -> int:
@@ -1625,6 +1708,8 @@ def run_eval_promptfoo_adapter(
     timeout: float,
     emit_json: bool,
     min_pass_rate: float | None,
+    policy: dict[str, Any] | None = None,
+    unsafe_fallback_applied: bool = False,
 ) -> int:
     """Delegate to a locally discovered ``promptfoo`` binary."""
     binary = _promptfoo_binary()
@@ -1643,7 +1728,7 @@ def run_eval_promptfoo_adapter(
         tmp_output = Path(tmp_file.name)
 
     try:
-        argv = [
+        inner_argv = [
             *command_list,
             "eval",
             "-c",
@@ -1651,6 +1736,30 @@ def run_eval_promptfoo_adapter(
             "--output",
             str(tmp_output),
         ]
+        # When --policy is active AND a sandbox backend is available, wrap the
+        # whole uvx/promptfoo invocation inside the declared sandbox. We ship
+        # uv into the default python:3.12-slim image via a pip-install shim so
+        # ``uvx promptfoo`` can resolve. Follow-up: vex/sandbox-eval:latest
+        # image with uv pre-baked (see issue #33 for the TODO).
+        if policy is not None and not unsafe_fallback_applied:
+            inner_cmd = " ".join(shlex.quote(part) for part in inner_argv)
+            if runner_name == "uvx":
+                shim = "command -v uvx >/dev/null 2>&1 || pip install --quiet uv"
+                shell_cmd = f"{shim} && {inner_cmd}"
+            else:
+                shell_cmd = inner_cmd
+            container_argv = build_sandbox_argv(shell_cmd, root, policy)
+            if container_argv is None:
+                # resolve_eval_sandbox() already validated backend presence;
+                # reaching here means state changed underneath us.
+                print(
+                    "vex eval --policy lost its sandbox backend between "
+                    "resolution and adapter launch."
+                )
+                return 2
+            argv = container_argv
+        else:
+            argv = inner_argv
         try:
             completed = subprocess.run(
                 argv,
@@ -1706,6 +1815,13 @@ def run_eval_promptfoo_adapter(
         command=f"{runner_name} promptfoo",
         dataset_path=dataset_path,
         config_path=config_path,
+    )
+
+    _stamp_policy_snapshot(
+        report,
+        policy=policy,
+        enforced=policy is not None and not unsafe_fallback_applied,
+        unsafe_fallback_applied=unsafe_fallback_applied,
     )
 
     _emit_eval_report(report, out_path, emit_json)
@@ -1934,6 +2050,8 @@ def run_eval_inspect_adapter(
     timeout: float,
     emit_json: bool,
     min_pass_rate: float | None,
+    policy: dict[str, Any] | None = None,
+    unsafe_fallback_applied: bool = False,
 ) -> int:
     """Delegate to a locally discovered Inspect AI CLI.
 
@@ -1952,7 +2070,7 @@ def run_eval_inspect_adapter(
 
     tmp_log_dir = Path(tempfile.mkdtemp(prefix="vex-inspect-"))
     try:
-        argv = [
+        inner_argv = [
             *command_list,
             "eval",
             str(config_path),
@@ -1961,6 +2079,25 @@ def run_eval_inspect_adapter(
             "--log-format",
             "json",
         ]
+        # Mirror promptfoo: wrap the whole uvx/inspect invocation inside the
+        # declared sandbox when --policy is active.
+        if policy is not None and not unsafe_fallback_applied:
+            inner_cmd = " ".join(shlex.quote(part) for part in inner_argv)
+            if runner_name == "uvx":
+                shim = "command -v uvx >/dev/null 2>&1 || pip install --quiet uv"
+                shell_cmd = f"{shim} && {inner_cmd}"
+            else:
+                shell_cmd = inner_cmd
+            container_argv = build_sandbox_argv(shell_cmd, root, policy)
+            if container_argv is None:
+                print(
+                    "vex eval --policy lost its sandbox backend between "
+                    "resolution and adapter launch."
+                )
+                return 2
+            argv = container_argv
+        else:
+            argv = inner_argv
         try:
             completed = subprocess.run(
                 argv,
@@ -2025,6 +2162,13 @@ def run_eval_inspect_adapter(
         config_path=config_path,
     )
 
+    _stamp_policy_snapshot(
+        report,
+        policy=policy,
+        enforced=policy is not None and not unsafe_fallback_applied,
+        unsafe_fallback_applied=unsafe_fallback_applied,
+    )
+
     _emit_eval_report(report, out_path, emit_json)
     if not emit_json:
         print(f"Eval report written to {out_path}")
@@ -2047,6 +2191,8 @@ def run_eval_harness(
     *,
     emit_json: bool = False,
     min_pass_rate: float | None = None,
+    policy: dict[str, Any] | None = None,
+    unsafe_fallback_applied: bool = False,
 ) -> int:
     uv = uv_bin()
     if uv is None:
@@ -2059,7 +2205,17 @@ def run_eval_harness(
         case_count = sum(1 for line in dataset_path.read_text(encoding="utf-8").splitlines() if line.strip())
 
     started = time.perf_counter()
-    code = run_command([uv, "run", "sh", "-c", command], cwd=root)
+    if policy is not None and not unsafe_fallback_applied:
+        container_argv = build_sandbox_argv(command, root, policy)
+        if container_argv is None:
+            print(
+                "vex eval --policy lost its sandbox backend between resolution "
+                "and harness launch."
+            )
+            return 2
+        code = run_command(container_argv)
+    else:
+        code = run_command([uv, "run", "sh", "-c", command], cwd=root)
     elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
 
     report = {
@@ -2077,6 +2233,13 @@ def run_eval_harness(
         "pass_rate": 100.0 if code == 0 else 0.0,
         "results": [],
     }
+
+    _stamp_policy_snapshot(
+        report,
+        policy=policy,
+        enforced=policy is not None and not unsafe_fallback_applied,
+        unsafe_fallback_applied=unsafe_fallback_applied,
+    )
 
     _emit_eval_report(report, out_path, emit_json)
     if not emit_json:
@@ -2110,6 +2273,8 @@ def run_eval_per_case_harness(
     *,
     emit_json: bool = False,
     min_pass_rate: float | None = None,
+    policy: dict[str, Any] | None = None,
+    unsafe_fallback_applied: bool = False,
 ) -> int:
     uv = uv_bin()
     if uv is None:
@@ -2120,6 +2285,8 @@ def run_eval_per_case_harness(
     results: list[dict[str, Any]] = []
     passed = 0
 
+    sandboxed = policy is not None and not unsafe_fallback_applied
+
     for index, case in enumerate(cases, start=1):
         input_text = str(case.get("input", ""))
         if "{input}" in command:
@@ -2128,7 +2295,20 @@ def run_eval_per_case_harness(
             case_command = f"{command} {shlex.quote(input_text)}" if input_text else command
 
         started = time.perf_counter()
-        code, stdout, stderr = run_command_capture([uv, "run", "sh", "-c", case_command], cwd=root)
+        if sandboxed:
+            assert policy is not None  # narrow for mypy
+            container_argv = build_sandbox_argv(case_command, root, policy)
+            if container_argv is None:
+                print(
+                    "vex eval --policy lost its sandbox backend between "
+                    "resolution and harness launch."
+                )
+                return 2
+            code, stdout, stderr = run_command_capture(container_argv)
+        else:
+            code, stdout, stderr = run_command_capture(
+                [uv, "run", "sh", "-c", case_command], cwd=root
+            )
         elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
 
         expect_contains = case.get("expect_contains")
@@ -2197,6 +2377,13 @@ def run_eval_per_case_harness(
         "pass_rate": round((passed / len(cases)) * 100, 2) if cases else 0.0,
         "results": results,
     }
+
+    _stamp_policy_snapshot(
+        report,
+        policy=policy,
+        enforced=policy is not None and not unsafe_fallback_applied,
+        unsafe_fallback_applied=unsafe_fallback_applied,
+    )
 
     _emit_eval_report(report, out_path, emit_json)
     if not emit_json:
@@ -2677,6 +2864,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=300.0,
         help="Timeout (seconds) for the adapter subprocess (default: 300).",
     )
+    eval_parser.add_argument(
+        "--policy",
+        dest="policy",
+        action="store_true",
+        help=(
+            "Run every eval case inside the sandbox declared in "
+            "[tool.vex.policy]. Requires sandbox = true; hard-fails with exit "
+            "code 2 when a sandbox backend is unavailable unless "
+            "unsafe_fallback = true."
+        ),
+    )
     eval_parser.add_argument("args", nargs=argparse.REMAINDER)
     eval_parser.set_defaults(handler=handle_eval)
 
@@ -3065,6 +3263,27 @@ def handle_eval(args: argparse.Namespace) -> int:
             )
             return 2
 
+    # --policy: optionally run every adapter under the declared sandbox.
+    policy_enabled = bool(getattr(args, "policy", False))
+    policy_dict: dict[str, Any] | None = None
+    unsafe_fallback_applied = False
+    if policy_enabled:
+        resolved_policy = load_vex_policy(root)
+        if not bool(resolved_policy.get("sandbox", True)):
+            print(
+                "vex eval --policy requires [tool.vex.policy].sandbox = true "
+                "(set sandbox = true in pyproject.toml or run "
+                "'vex policy set sandbox true --type bool')"
+            )
+            return 2
+        _prefix, fallback_applied, exit_code = resolve_eval_sandbox(
+            root, resolved_policy
+        )
+        if exit_code != 0:
+            return exit_code
+        policy_dict = {str(key): value for key, value in resolved_policy.items()}
+        unsafe_fallback_applied = fallback_applied
+
     # Adapter selection precedence:
     # 1. explicit --command -> always use harness (per-case or single)
     # 2. --no-promptfoo (deprecated) -> treat as --adapter harness, warn
@@ -3138,6 +3357,8 @@ def handle_eval(args: argparse.Namespace) -> int:
             timeout=max(1.0, float(args.timeout)),
             emit_json=bool(args.emit_json),
             min_pass_rate=min_pass_rate,
+            policy=policy_dict,
+            unsafe_fallback_applied=unsafe_fallback_applied,
         )
 
     if selected_adapter == "promptfoo" and promptfoo_path is not None:
@@ -3151,6 +3372,8 @@ def handle_eval(args: argparse.Namespace) -> int:
             timeout=max(1.0, float(args.timeout)),
             emit_json=bool(args.emit_json),
             min_pass_rate=min_pass_rate,
+            policy=policy_dict,
+            unsafe_fallback_applied=unsafe_fallback_applied,
         )
 
     command = args.command
@@ -3173,6 +3396,8 @@ def handle_eval(args: argparse.Namespace) -> int:
             out_path=out_path,
             emit_json=bool(args.emit_json),
             min_pass_rate=min_pass_rate,
+            policy=policy_dict,
+            unsafe_fallback_applied=unsafe_fallback_applied,
         )
     return run_eval_harness(
         root,
@@ -3181,6 +3406,8 @@ def handle_eval(args: argparse.Namespace) -> int:
         out_path=out_path,
         emit_json=bool(args.emit_json),
         min_pass_rate=min_pass_rate,
+        policy=policy_dict,
+        unsafe_fallback_applied=unsafe_fallback_applied,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1830,6 +1830,290 @@ class CliTests(unittest.TestCase):
         # Human-friendly summary suppressed when --json is set.
         self.assertNotIn("Eval report written", output)
 
+    # ------------------------------------------------------------------
+    # vex eval --policy
+    # ------------------------------------------------------------------
+
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_eval_policy_wraps_harness_in_sandbox(
+        self,
+        run_command: object,
+        _uv_bin: object,
+        _backend: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'network = "deny"\n'
+                'filesystem = "project"\n'
+                'sandbox_backend = "docker"\n'
+                'sandbox_image = "python:3.12-slim"\n'
+                "sandbox_memory_mb = 1024\n"
+                "sandbox_pids_limit = 128\n"
+                "unsafe_fallback = false\n",
+                encoding="utf-8",
+            )
+            (root / "evals" / "datasets").mkdir(parents=True)
+            (root / "evals" / "datasets" / "cases.jsonl").write_text(
+                '{"input":"a"}\n', encoding="utf-8"
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(
+                    [
+                        "eval",
+                        "--policy",
+                        "--command",
+                        "python -c 'print(1)'",
+                        "--out",
+                        "artifacts/evals/policy.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        run_command.assert_called_once()
+        invoked_argv = run_command.call_args.args[0]
+        # The sandbox prefix must be the literal docker run --rm ... shape.
+        self.assertEqual(invoked_argv[0], "docker")
+        self.assertEqual(invoked_argv[1], "run")
+        self.assertEqual(invoked_argv[2], "--rm")
+        self.assertIn("--network", invoked_argv)
+        self.assertIn("--cap-drop", invoked_argv)
+        self.assertIn("ALL", invoked_argv)
+        self.assertIn("--read-only", invoked_argv)
+        # sh -c <command> must appear verbatim at the end.
+        self.assertEqual(invoked_argv[-3], "sh")
+        self.assertEqual(invoked_argv[-2], "-c")
+        self.assertEqual(invoked_argv[-1], "python -c 'print(1)'")
+
+    def test_eval_policy_fails_when_sandbox_disabled(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = false\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--policy",
+                        "--command",
+                        "python -c 'print(1)'",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 2)
+        self.assertIn("requires [tool.vex.policy].sandbox = true", output)
+        self.assertIn("vex policy set sandbox true --type bool", output)
+
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_eval_policy_stamps_report_with_policy_snapshot(
+        self,
+        _run_command: object,
+        _uv_bin: object,
+        _backend: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'network = "deny"\n'
+                'filesystem = "project"\n'
+                'sandbox_backend = "docker"\n'
+                'sandbox_image = "python:3.12-slim"\n'
+                "sandbox_memory_mb = 1024\n"
+                "sandbox_pids_limit = 128\n"
+                "unsafe_fallback = false\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(
+                    [
+                        "eval",
+                        "--policy",
+                        "--command",
+                        "python -c 'print(1)'",
+                        "--out",
+                        "artifacts/evals/policy-stamp.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "policy-stamp.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(report["schema"], "vex-eval/v1")
+        self.assertIn("policy", report)
+        policy = report["policy"]
+        self.assertEqual(policy["enforced"], True)
+        self.assertEqual(policy["network"], "deny")
+        self.assertEqual(policy["filesystem"], "project")
+        self.assertEqual(policy["sandbox_backend"], "docker")
+        self.assertEqual(policy["sandbox_image"], "python:3.12-slim")
+        self.assertEqual(policy["sandbox_memory_mb"], 1024)
+        self.assertEqual(policy["sandbox_pids_limit"], 128)
+        self.assertEqual(policy["unsafe_fallback_applied"], False)
+
+    @patch("vex.cli.sandbox_backend", return_value="none")
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_eval_policy_honors_unsafe_fallback(
+        self,
+        run_command: object,
+        _uv_bin: object,
+        _backend: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'sandbox_backend = "none"\n'
+                "unsafe_fallback = true\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    [
+                        "eval",
+                        "--policy",
+                        "--command",
+                        "python -c 'print(1)'",
+                        "--out",
+                        "artifacts/evals/policy-fallback.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            report = json.loads(
+                (root / "artifacts" / "evals" / "policy-fallback.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(code, 0)
+        self.assertIn("unsafe_fallback=true", output)
+        # Ran locally (not wrapped): first two args are [uv, "run"].
+        invoked_argv = run_command.call_args.args[0]
+        self.assertEqual(invoked_argv[:2], ["uv", "run"])
+        # Report must mark enforcement off and fallback on.
+        self.assertEqual(report["policy"]["enforced"], False)
+        self.assertEqual(report["policy"]["unsafe_fallback_applied"], True)
+
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.shutil.which")
+    @patch("vex.cli.subprocess.run")
+    def test_eval_policy_wraps_promptfoo_uvx_invocation(
+        self,
+        subprocess_run: object,
+        which_mock: object,
+        _backend: object,
+    ) -> None:
+        which_mock.side_effect = lambda name: "/usr/local/bin/uvx" if name == "uvx" else None
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+            # The sandboxed invocation no longer writes a tmp output file on
+            # the host (it would run inside the container). Return empty
+            # results so the normalizer produces an empty report.
+            output_path_idx = None
+            if "--output" in argv:
+                output_path_idx = argv.index("--output") + 1
+            if output_path_idx is not None and output_path_idx < len(argv):
+                candidate = Path(argv[output_path_idx])
+                # Only write to host paths; skip container /workspace paths.
+                if candidate.is_absolute() and candidate.parent.exists():
+                    candidate.write_text(
+                        json.dumps({"results": {"results": []}}),
+                        encoding="utf-8",
+                    )
+            return _Completed()
+
+        subprocess_run.side_effect = _fake_run
+
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'network = "deny"\n'
+                'sandbox_backend = "docker"\n'
+                'sandbox_image = "python:3.12-slim"\n',
+                encoding="utf-8",
+            )
+            (root / "promptfooconfig.yaml").write_text(
+                "providers: []\n", encoding="utf-8"
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(
+                    [
+                        "eval",
+                        "--policy",
+                        "--adapter",
+                        "promptfoo",
+                        "--out",
+                        "artifacts/evals/policy-promptfoo.json",
+                    ]
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        # No adapter content, exit code should be 0 (no failures detected) or
+        # 1 if the normalizer treats 0/0 as non-failing; the key assertion
+        # is the shape of the subprocess argv.
+        self.assertIn(code, (0, 1))
+        self.assertEqual(subprocess_run.call_count, 1)
+        invoked_argv = subprocess_run.call_args.args[0]
+        # Sandbox prefix.
+        self.assertEqual(invoked_argv[0], "docker")
+        self.assertEqual(invoked_argv[1], "run")
+        self.assertEqual(invoked_argv[2], "--rm")
+        self.assertIn("python:3.12-slim", invoked_argv)
+        # sh -c <shell_cmd> contains the uvx promptfoo invocation.
+        self.assertEqual(invoked_argv[-3], "sh")
+        self.assertEqual(invoked_argv[-2], "-c")
+        self.assertIn("uvx", invoked_argv[-1])
+        self.assertIn("promptfoo", invoked_argv[-1])
+        # Shim for uv-less default image.
+        self.assertIn("pip install", invoked_argv[-1])
+
     @patch("vex.cli.docker_like_bin", return_value="docker")
     @patch("vex.cli.run_command", return_value=0)
     def test_deploy_docker_builds_image(self, run_command: object, _docker: object) -> None:


### PR DESCRIPTION
## Summary

Closes #33. Adds `--policy` to `vex eval` so every adapter (harness, per-case, promptfoo, inspect) runs inside the sandbox declared in `[tool.vex.policy]` — the same machinery as `vex run --sandbox`.

- Extracts `build_sandbox_argv()` out of `run_sandboxed()` so adapters can reuse the sandbox argv builder.
- Stamps a `policy` block into the normalized `vex-eval/v1` report (additive, schema unchanged): `enforced`, `network`, `filesystem`, `sandbox_backend`, `sandbox_image`, `sandbox_memory_mb`, `sandbox_pids_limit`, `unsafe_fallback_applied`.
- Hard-fails up front for the two ergonomic footguns:
  - `policy.sandbox = false` + `--policy` → exit 2, pointer at `vex policy set sandbox true --type bool`.
  - No sandbox backend + `unsafe_fallback = false` → exit 2, pointer at `vex doctor ai`.
  - `unsafe_fallback = true` + no backend → runs locally, report marks `enforced: false, unsafe_fallback_applied: true`.

## Behavior per adapter

- `harness` (single-shot) — `run_command([backend, "run", "--rm", ..., image, "sh", "-c", command])`; replaces the unsandboxed `uv run sh -c ...` invocation.
- `per-case` — each case's `sh -c <case_command>` wrapped in the sandbox; a fresh container per case keeps cross-case isolation aligned with production.
- `promptfoo` / `inspect` — the whole `uvx promptfoo ...` / `uvx --from inspect-ai inspect ...` invocation is wrapped, so the eval engine itself runs sandboxed.

## Sandbox-image-needs-uv tradeoff

The default `sandbox_image = "python:3.12-slim"` does not ship `uv`. When `--policy` is active and the adapter is `promptfoo` or `inspect`, the adapter prepends a one-shot shim before the `uvx` call:

```sh
command -v uvx >/dev/null 2>&1 || pip install --quiet uv && uvx ...
```

This is a deliberate pragmatic default (every image already has pip; `--quiet` keeps logs clean). Follow-up: ship `vex/sandbox-eval:latest` with `uv` pre-baked and drop the shim (noted in `docs/eval.md`).

## Tests

Added five tests covering all the edge cases called out in #33:

- `test_eval_policy_wraps_harness_in_sandbox` — argv starts with `[backend, "run", "--rm", ...]`, ends with `sh -c <command>`.
- `test_eval_policy_fails_when_sandbox_disabled` — exit 2 + pointer message.
- `test_eval_policy_stamps_report_with_policy_snapshot` — report has the expected `policy` keys.
- `test_eval_policy_honors_unsafe_fallback` — runs locally, report marks `enforced=false, unsafe_fallback_applied=true`.
- `test_eval_policy_wraps_promptfoo_uvx_invocation` — sandbox argv wraps `uvx promptfoo ...` and contains the `pip install` shim.

Full suite: `PYTHONPATH=src python3 -m unittest tests.test_cli` → 78/78 pass (73 existing + 5 new). `make test-vex` → 79/79 pass (1 skipped).

## Docs / README

- `README.md` — "near-future" bullet for `vex eval --policy` removed; the headline paragraph now reads present-tense. The deploy gate remains as the only near-future item.
- `docs/eval.md` — new `--policy` section with the argv shape, the `policy` report block, and the hard-fail conditions.
- `docs/policy.md` — new "Enforcement surfaces" section linking out to the eval page.

## Out of scope

- Auto-inferring allowed tools from agent code (separate, harder problem).
- Shipping `vex/sandbox-eval:latest` with `uv` pre-baked — noted as a follow-up in `docs/eval.md`.
- Network-enforced eval mode (v2).

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` passes locally.
- [x] New tests assert the exact argv shape for each adapter path.
- [ ] Manual smoke: `vex eval --policy --command "python -c 'print(1)'"` under a real docker daemon.