### PR TITLE
docs: add cli-reference, doctor, and troubleshooting pages (#35)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,491 @@
+# CLI reference
+
+Every `vex` verb is a thin wrapper around `uv` or a target-specific CLI.
+This page is a per-verb flag and exit-code reference; see [`eval.md`](eval.md),
+[`policy.md`](policy.md), and [`deploy.md`](deploy.md) for the deeper behavior
+of the AI workflow verbs.
+
+Global flags:
+
+- `--version` — print the installed `vex` version and exit 0.
+
+When `vex` is invoked with no subcommand it prints help and exits 0.
+
+## AI workflow verbs
+
+### `vex init`
+
+Scaffold a new vex-managed project by delegating to `uv init` and then
+appending `[tool.vex]` configuration, optional AI template files, and a
+`deploy.targets.toml` profile.
+
+Positional arguments (both optional):
+
+- `template_or_path` — either one of the AI templates (`agent`,
+  `inference-api`) or a destination path.
+- `path` — the destination path when the first argument was a template.
+
+Flags:
+
+- `--name <str>` — project name forwarded to `uv init --name`; also the seed
+  for the derived package name written into `[tool.vex]`.
+- `--python <str>` — Python version forwarded to `uv init --python`. When
+  omitted, the scaffold pins to `3.12` and normalizes `requires-python` to
+  `>=3.11` so projects stay portable across developer machines.
+- `--app` — passthrough to `uv init --app --no-package` (non-packaged app).
+- `--lib` — passthrough to `uv init --lib --package --build-backend hatch`.
+  Mutually exclusive with `--app`.
+
+Exit codes:
+
+- `0` — scaffold succeeded.
+- `2` — invalid template / path combination (e.g. `vex init agent foo bar`).
+- non-zero — whatever `uv init` returned; `127` if `uv` is not on PATH.
+
+Config written after init:
+
+- `[tool.vex]` block inside `pyproject.toml` (package name, template marker).
+- `[tool.vex.scripts]` with the template's `dev` / `benchmark` / `eval`
+  entrypoints.
+- `[tool.vex.policy]` block with sandbox defaults (see [`policy.md`](policy.md)).
+- `deploy.targets.toml` with `profiles.default` and `profiles.prod`.
+
+Example:
+
+```bash
+vex init agent support-bot --name support-bot
+```
+
+### `vex dev`
+
+Run the project's `[tool.vex.scripts].dev` command under `uv run` with
+file-watching reload and an LLM provider banner.
+
+Flags:
+
+- `--no-reload` — disable watchfiles reload; run the dev command once under
+  `uv run` and forward its exit code.
+- `--watch <path>` — extra path to watch; repeatable. Added on top of
+  `src/` (when present) and `[tool.vex.dev].watch`.
+- `--provider-check` / `--no-provider-check` — toggle the
+  `[vex dev] provider=...` banner. Default: on. The banner warns when
+  `provider=ollama` but `ollama` is not on PATH.
+- trailing args — forwarded verbatim to the dev command.
+
+Exit codes:
+
+- `0` — dev command exited cleanly.
+- `2` — no `[tool.vex.scripts].dev` configured.
+- `127` — `uv` not on PATH.
+- `130` — SIGINT during watch loop.
+
+Config sources:
+
+- `[tool.vex.scripts].dev` (required).
+- `[tool.vex.dev].watch` — list of extra paths to watch.
+- Environment: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` (used by the provider
+  banner heuristic; see `resolve_dev_provider`).
+
+Example:
+
+```bash
+vex dev --watch config/
+```
+
+### `vex eval`
+
+Run dataset-driven evaluations and emit a normalized `vex-eval/v1` report.
+See [`eval.md`](eval.md) for adapter precedence and the report schema.
+
+Flags:
+
+- `--command <str>` — shell command to run; forces the built-in harness.
+- `--dataset <path>` — dataset path (default: `evals/datasets/cases.jsonl`).
+- `--out <path>` — report output path (default: `artifacts/evals/latest.json`).
+- `--per-case` — with the harness, run the command once per case and gate on
+  per-case expectations.
+- `--json` — print the normalized report JSON to stdout and suppress the
+  human summary.
+- `--min-pass-rate <float>` — fraction in `[0.0, 1.0]`; fail when
+  `pass_rate / 100` falls below this. Falls back to
+  `[tool.vex.eval].min_pass_rate`.
+- `--adapter {auto,inspect,promptfoo,harness}` — override adapter selection.
+  `auto` prefers Inspect AI, then promptfoo, then harness.
+- `--no-promptfoo` — deprecated alias for `--adapter harness`; emits a
+  warning.
+- `--timeout <float>` — adapter subprocess timeout in seconds (default
+  `300.0`).
+- trailing args — appended to the resolved command (harness only).
+
+Exit codes:
+
+- `0` — all cases passed (and the min-pass-rate gate was met).
+- `1` — at least one case failed, or `--min-pass-rate` gate missed.
+- `2` — invalid arguments (out-of-range `--min-pass-rate`, missing command or
+  adapter config).
+- `124` — adapter subprocess exceeded `--timeout`.
+- `127` — required adapter binary (`uvx` / `inspect` / `promptfoo`) not
+  available.
+
+Config sources:
+
+- `[tool.vex.scripts].eval` — default command when `--command` is omitted.
+- `[tool.vex.eval].adapter` — default adapter.
+- `[tool.vex.eval].min_pass_rate` — default gate threshold.
+- Adapter configs at project root: `inspect.yaml` / `inspect.toml` /
+  `evals/*.inspect.py` for Inspect AI; `promptfooconfig.yaml` for promptfoo.
+
+Example:
+
+```bash
+vex eval --adapter promptfoo --json --min-pass-rate 0.9 > results.json
+```
+
+### `vex deploy`
+
+Build or ship the project to docker, Cloud Run, or Modal. Preflight runs
+automatically before `--apply` / `--run`. See [`deploy.md`](deploy.md) for
+target-specific behavior.
+
+Positional argument:
+
+- `target` — one of `docker`, `cloud-run`, `modal`, or `check`.
+
+Flags:
+
+- `--image <str>` — OCI image name (default `vex-app`). Profile override key
+  `image`.
+- `--tag <str>` — image tag (default `latest`). Profile override key `tag`.
+- `--push` — docker only; push after build. Profile override key `push`.
+- `--service <str>` — Cloud Run service name (default `vex-ai-service`).
+- `--region <str>` — Cloud Run region (default `us-central1`).
+- `--project <str>` — GCP project (falls back to `GOOGLE_CLOUD_PROJECT` or
+  `gcloud config` default).
+- `--app-name <str>` — Modal app name (default `vex-ai-app`). Profile
+  override keys `app_name` / `app-name`.
+- `--apply` — after scaffolding, apply via the vendor CLI (runs preflight
+  first unless `--skip-preflight`).
+- `--run` — docker: build + run locally; modal: `modal deploy` the
+  scaffold. Runs preflight first unless `--skip-preflight`. (Cloud Run
+  deploys are triggered by `--apply`, not `--run`.)
+- `--port <int>` — port mapping for `docker --run` (default `8000`).
+- `--profile <str>` — `deploy.targets.toml` profile to apply (default
+  `default`).
+- `--skip-preflight` — bypass the automatic preflight for `--apply`/`--run`.
+- `--for {all,docker,cloud-run,modal}` — with `target=check`, restrict the
+  preflight scope (default `all`).
+
+Exit codes:
+
+- `0` — scaffold / apply / run succeeded; for `target=check` also returned
+  when no preflight issues are reported.
+- `1` — preflight reported one or more issues (either for `check` or before
+  `--apply`/`--run`).
+- `2` — unsupported target.
+- `127` — required vendor CLI (`docker`/`podman`/`gcloud`/`modal`) missing.
+- non-zero — whatever the vendor CLI returned.
+
+Config sources:
+
+- `deploy.targets.toml` — profiles, env interpolation, inheritance.
+- Environment: `GOOGLE_CLOUD_PROJECT`, `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`,
+  and anything referenced as `${VAR}` in profile values.
+
+Examples:
+
+```bash
+vex deploy cloud-run --apply --profile prod
+vex deploy docker --run --port 8080
+```
+
+### `vex deploy check`
+
+Run preflight against the local environment without building or deploying.
+
+Flags:
+
+- `--for {all,docker,cloud-run,modal}` — scope (default `all`).
+- All `vex deploy` profile flags are accepted and applied to the resolved
+  profile (for instance `--image` / `--tag` for the reported `image:tag`).
+
+Exit codes:
+
+- `0` — no issues reported.
+- `1` — one or more WARN lines.
+
+See [`deploy.md`](deploy.md) for the full check list.
+
+Example:
+
+```bash
+vex deploy check --for cloud-run
+```
+
+### `vex policy`
+
+Inspect and override the effective `[tool.vex.policy]` configuration. See
+[`policy.md`](policy.md) for the schema and sandbox enforcement.
+
+Subcommands:
+
+- `list` — print every resolved policy key on stdout (default when no
+  subcommand).
+- `get <key>` — print a single value; exit `1` when the key is missing.
+- `set <key> <value> [--type {auto,str,bool,int,float,json}]` — write an
+  override to `.vex/policy.json`. `auto` tries bool, then int, then float,
+  then falls back to string.
+- `unset <key>` — remove an override from `.vex/policy.json`.
+
+Exit codes:
+
+- `0` — success.
+- `1` — `get` called with a missing key.
+- `2` — `set` value could not be parsed, or unknown subcommand.
+
+Config sources:
+
+- `[tool.vex.policy]` in `pyproject.toml` (base).
+- `.vex/policy.json` (per-developer override, layered on top).
+
+Example:
+
+```bash
+vex policy set unsafe_fallback true --type bool
+```
+
+### `vex run`
+
+Run a script alias or arbitrary command under `uv run`, optionally inside a
+sandbox container.
+
+Flags:
+
+- `--sandbox` — run the resolved command inside the sandbox backend
+  (`docker` or `podman`) configured by `[tool.vex.policy]`. See
+  [`policy.md`](policy.md) for the exact container flags.
+- trailing args — script alias or shell command.
+
+Exit codes:
+
+- `0` / propagated — whatever the command returned.
+- `2` — no command supplied, or sandbox disabled by policy
+  (`sandbox=false`).
+- `127` — `uv` not on PATH.
+
+Config sources:
+
+- `[tool.vex.scripts].<name>` — script alias lookup.
+- `[tool.vex.policy]` — sandbox backend, image, network, memory, pids
+  limits.
+- `.vex/policy.json` — per-developer overrides.
+
+Examples:
+
+```bash
+vex run smoke                   # resolves [tool.vex.scripts].smoke
+vex run --sandbox "pytest -q"
+```
+
+### `vex package-model`
+
+Create a packaged model artifact manifest (`vex-model.json`) suitable for
+`vex-ai-runtime`.
+
+Positional:
+
+- `model` — path to the source model file.
+
+Flags:
+
+- `--out-dir <path>` — output directory (default `build/model-artifact`).
+- `--name <str>` — artifact name (default: the source filename stem).
+- `--sha256 <str>` — pre-computed digest; when omitted, the CLI computes the
+  hash itself.
+- `--skip-compat-check` — skip the runtime compatibility validation step.
+
+Exit codes:
+
+- `0` — manifest written (and compat check passed, if run).
+- `2` — invalid input (missing source file, incompatible artifact).
+
+Config sources:
+
+- `VEX_AI_RUNTIME_PATH` — override for the shared schema location.
+- `engine/vex-ai-runtime/schemas/vex-model-schema.json` — shared schema used
+  to stamp the manifest's `schema` / `schema_version` / `runtime` / `engine`
+  fields.
+
+Example:
+
+```bash
+vex package-model models/classifier.onnx --name classifier
+```
+
+### `vex schema validate-model`
+
+Validate a packaged model artifact against the runtime's load path.
+
+Positional:
+
+- `artifact_dir` — directory to validate (default `build/model-artifact`).
+
+Flags:
+
+- `--strict-runtime` — treat a missing runtime as an error; default is to
+  skip the check with a notice.
+
+Exit codes:
+
+- `0` — compatibility check passed (or was skipped without `--strict-runtime`).
+- `2` — validation failed, or subcommand was omitted.
+
+Config sources: same as `vex package-model`.
+
+Example:
+
+```bash
+vex schema validate-model build/model-artifact --strict-runtime
+```
+
+### `vex doctor`
+
+Run readiness checks against the project. Optional positional `scope`
+(`ai`) runs the extended AI scope. See [`doctor.md`](doctor.md) for the full
+list of checks.
+
+Exit codes:
+
+- `0` — no issues reported.
+- `1` — one or more WARN / ERR lines.
+
+Example:
+
+```bash
+vex doctor ai
+```
+
+### `vex benchmark`
+
+Time a shell command across warmup and measured runs, emitting a
+`vex-benchmark/v1` report.
+
+Flags:
+
+- `--command <str>` — command to benchmark. When omitted, falls back to
+  `[tool.vex.scripts].benchmark`, then `python -m timeit -n 1000 -r 5 '1+1'`.
+- `--runs <int>` — measured iterations (default `5`).
+- `--warmup <int>` — warmup iterations (default `1`).
+- `--out <path>` — report path (default `artifacts/benchmarks/latest.json`).
+- trailing args — appended to the resolved command.
+
+Exit codes:
+
+- `0` — every measured run exited `0`.
+- non-zero — propagated from the first failing run.
+- `127` — `uv` not on PATH.
+
+Config sources:
+
+- `[tool.vex.scripts].benchmark` — default command.
+
+Example:
+
+```bash
+vex benchmark --runs 20 --warmup 3 --command "python -m app.bench"
+```
+
+## uv passthroughs
+
+These verbs delegate directly to `uv`. They exist so the workflow stays
+`vex`-native even when the real work is pure `uv`.
+
+### `vex add` / `vex remove` / `vex sync` / `vex lock`
+
+- `vex add <packages...> [--dev | --group <name>]` — `uv add`.
+- `vex remove <packages...> [--dev | --group <name>]` — `uv remove`.
+- `vex sync [--frozen] [--group <name> ...]` — `uv sync`.
+- `vex lock [--upgrade] [packages...]` — `uv lock`; extra packages map to
+  repeated `--upgrade-package <name>` flags.
+
+Exit codes: propagated from `uv`; `127` when `uv` is not on PATH.
+
+Example:
+
+```bash
+vex add pydantic-ai --group agent
+```
+
+### `vex test` / `vex lint` / `vex format` / `vex typecheck`
+
+Run the project's `[tool.vex.scripts].<name>` command under `uv run sh -c`
+when configured; otherwise fall back to the DEFAULT_SCRIPT_COMMANDS:
+
+- `test` → `uv run --with pytest pytest`
+- `lint` → `uv run --with ruff ruff check .`
+- `format` → `uv run --with ruff ruff format .`
+- `typecheck` → `uv run --with mypy mypy .`
+
+Trailing args are appended to the resolved command.
+
+Exit codes: propagated from the underlying tool; `127` when `uv` is not on
+PATH.
+
+Example:
+
+```bash
+vex test -k agent
+```
+
+### `vex python`
+
+Manage Python interpreters via `uv python`.
+
+Subcommands:
+
+- `install <version>` — `uv python install <version>`.
+- `pin <version>` — `uv python pin <version>`.
+- `list` — `uv python list`.
+- `path` — `uv python find`.
+- `uninstall <version>` — `uv python uninstall <version>`.
+
+Exit codes: propagated from `uv`.
+
+Example:
+
+```bash
+vex python install 3.12
+```
+
+### `vex build` / `vex publish`
+
+- `vex build [--wheel] [--sdist]` — `uv build`.
+- `vex publish [--repository <url>]` — `uv publish`; `--repository` is
+  forwarded as `uv publish --index <url>`.
+
+Exit codes: propagated from `uv`.
+
+Example:
+
+```bash
+vex build --wheel --sdist
+```
+
+### `vex tool`
+
+Manage isolated Python CLI tools via `uv tool`.
+
+Subcommands:
+
+- `run <tool_name> [args...]` — `uv tool run <tool_name> ...`.
+- `install <tool_name>` — `uv tool install <tool_name>`.
+- `list` — `uv tool list`.
+- `upgrade` — `uv tool upgrade` (all tools).
+- `uninstall <tool_name>` — `uv tool uninstall <tool_name>`.
+
+Exit codes: propagated from `uv`.
+
+Example:
+
+```bash
+vex tool run ruff check .
+```

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,227 @@
+# vex doctor — readiness checks
+
+`vex doctor` reports one `OK`, `WARN`, or `ERR` line per check and exits `0`
+when no issues were reported, `1` otherwise. Two scopes exist:
+
+- `vex doctor` — base scope, always runs.
+- `vex doctor ai` — additive scope for AI projects (policy, deploy profile,
+  runtime, sandbox, providers, observability, eval datasets, deploy env).
+
+Ground truth: `doctor_checks` in `src/vex/cli.py`.
+
+## vex doctor (base scope)
+
+### uv availability
+
+- `OK  uv found at <path>` — `uv` resolved via `shutil.which`.
+- `ERR uv not found on PATH`
+
+Fix: install `uv` per https://docs.astral.sh/uv/getting-started/installation/.
+
+### pyproject.toml present
+
+- `OK  found pyproject.toml`
+- `ERR missing pyproject.toml` — subsequent checks are skipped.
+
+Fix: run `vex init` (or `uv init`) in the project root.
+
+### pyproject.toml parses
+
+- `OK  pyproject.toml parsed successfully`
+- `ERR could not parse pyproject.toml` — subsequent checks are skipped.
+
+Fix: repair the TOML syntax; `python -c "import tomllib; tomllib.loads(open('pyproject.toml').read())"`
+prints the exact parse error.
+
+### `[tool.vex]` section
+
+- `OK  found [tool.vex] configuration`
+- `WARN missing [tool.vex] configuration`
+
+Fix: add a `[tool.vex]` block, or re-run `vex init` to generate one.
+
+### uv.lock present
+
+- `OK  found uv.lock`
+- `WARN missing uv.lock; run 'vex sync' or 'vex lock'`
+
+Fix: `vex sync` or `vex lock`.
+
+### Environment directory
+
+- `OK  environment directory exists at <path>`
+- `WARN environment directory missing at <path>`
+
+`<path>` is `[tool.vex.env].path` if set, else `.venv`.
+
+Fix: `vex sync`.
+
+### `[tool.vex.scripts]` aliases
+
+- `OK  found vex scripts: <names>`
+- `WARN no [tool.vex.scripts] aliases configured`
+
+Fix: add a `[tool.vex.scripts]` table to `pyproject.toml`, for example:
+
+```toml
+[tool.vex.scripts]
+dev = "python -m myapp.main"
+eval = "python -m myapp.eval"
+```
+
+## vex doctor ai (AI scope — additive)
+
+All base-scope checks run first. The AI scope adds the following.
+
+### AI workflow scripts
+
+For each of `dev`, `benchmark`, and `eval`:
+
+- `OK  found AI workflow script '<name>'`
+- `WARN missing AI workflow script '<name>'`
+
+Fix: add the missing alias under `[tool.vex.scripts]` in `pyproject.toml`.
+
+### `[tool.vex.policy]` section
+
+- `OK  found [tool.vex.policy] with keys: <keys>` — either an inline policy
+  block or an override in `.vex/policy.json` was detected.
+- `WARN missing [tool.vex.policy] configuration`
+
+Fix: add a `[tool.vex.policy]` block (see [`policy.md`](policy.md) for the
+schema), or run `vex policy set <key> <value>` to seed
+`.vex/policy.json`.
+
+### `deploy.targets.toml` with default profile
+
+- `OK  found deploy.targets.toml with default profile`
+- `WARN missing deploy.targets.toml default profile`
+
+Fix: create `deploy.targets.toml` with a `[profiles.default]` table (see
+[`deploy.md`](deploy.md)), or re-run `vex init` with an AI template so the
+scaffold writes one.
+
+### Runtime path
+
+- `OK  runtime path resolved to <path>`
+- `WARN runtime path not resolved (set VEX_AI_RUNTIME_PATH if needed)`
+
+The CLI searches, in order, `engine/vex-ai-runtime/`, `../vex-ai-runtime/`,
+`./vex-ai-runtime/`, `../../vex-ai-runtime/`, and
+`packages/vex-ai-runtime/`.
+
+Fix: export `VEX_AI_RUNTIME_PATH=<abs path>` to point at your runtime
+checkout, or place it in one of the searched locations.
+
+### Shared model schema
+
+- `OK  found shared model schema in runtime`
+- `WARN runtime schema file missing`
+
+Runs only when the runtime path was resolved. Checks for
+`<runtime>/schemas/vex-model-schema.json`.
+
+Fix: update your `vex-ai-runtime` checkout so the schema file is present.
+
+### Sandbox backend
+
+Only runs when `policy.sandbox` is `true`.
+
+- `OK  sandbox backend detected: <docker|podman>` — from
+  `sandbox_backend(policy)`.
+- `WARN no sandbox backend detected (install docker or podman)`
+
+Fix: install `docker` or `podman` on PATH, or set
+`[tool.vex.policy].sandbox = false` if you don't need sandboxed runs.
+
+### Sandbox image cache
+
+Only runs when a sandbox backend was detected. Relies on
+`sandbox_image_cached`, which shells out to `<backend> image inspect <image>`.
+
+- `OK  sandbox image cached locally: <image>`
+- `WARN sandbox image not cached locally: <image> (run: <backend> pull <image>)`
+
+Fix: run the printed `<backend> pull <image>` command once to warm the cache.
+
+### Hosted provider credentials
+
+Checks each of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and
+`GROQ_API_KEY`.
+
+- `OK  hosted provider credential detected: <name> (<ENV>)`
+- `WARN OPENAI_API_KEY set but does not start with 'sk-' (looks malformed)` —
+  accepts the `ollama` prefix as well.
+- `WARN ANTHROPIC_API_KEY set but does not start with 'sk-ant-' (looks malformed)`
+
+Fix: export a real credential (`export OPENAI_API_KEY=sk-...`), or unset the
+malformed value and rely on the ollama fallback.
+
+### Ollama fallback
+
+- `OK  no hosted provider keys; ollama available on PATH (local fallback)` —
+  no hosted keys set but `ollama` binary found.
+- `OK  ollama available on PATH (local fallback)` — hosted keys present and
+  `ollama` also available.
+- `WARN no hosted provider keys set and 'ollama' not on PATH (install ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY)`
+
+Fix: install ollama from https://ollama.com or set one of the hosted keys.
+
+### `.env.example` declared keys
+
+- `OK  .env.example declares <N> provider key(s); none set — will use ollama fallback`
+- `WARN .env.example declares <N> provider key(s) but none are set in the environment` —
+  only emitted when ollama is also unavailable.
+
+Fix: export the declared keys (or a subset) in your shell or `.env`, or
+install ollama.
+
+### Observability
+
+One of:
+
+- `OK  observability: logfire` — `LOGFIRE_TOKEN` is set.
+- `OK  observability: otel endpoint=<host>` — `OTEL_EXPORTER_OTLP_ENDPOINT`
+  is set; the host (with port if present) is echoed back.
+- `WARN no observability configured (set LOGFIRE_TOKEN or OTEL_EXPORTER_OTLP_ENDPOINT)`
+
+Fix: export `LOGFIRE_TOKEN=...` or `OTEL_EXPORTER_OTLP_ENDPOINT=https://collector:4318`.
+
+### Eval dataset shape
+
+Runs only when `evals/datasets/` exists. For each `.jsonl` file:
+
+- `OK  eval dataset <path>: <N> cases valid`
+- `WARN evals/datasets/ present but no .jsonl datasets found`
+- `WARN <path> has no cases`
+- `WARN <path>: <N> rows, <B> invalid JSON, <M> missing 'input' field`
+- `WARN could not read <path>: <OS error>`
+
+Fix: make each dataset line a standalone JSON object with at least an
+`input` field. Validate quickly with
+`python -c "import json; [json.loads(l) for l in open('evals/datasets/cases.jsonl')]"`.
+
+### Deploy env var interpolation
+
+Runs only when `deploy.targets.toml` exists. Extracts every `${VAR}` token
+from the file and checks each against the process environment.
+
+- `OK  deploy.targets.toml env vars bound (<N> referenced)`
+- `WARN deploy.targets.toml references unbound env vars: <names>`
+
+Fix: export the missing variables, or add them to a `.env` file sourced
+before `vex deploy`.
+
+### Schema drift
+
+- `WARN schema drift detected between vex and vex-ai-runtime for keys: <keys>` —
+  emitted when the local `VEX_MODEL_SCHEMA_ID`, schema version, runtime, or
+  engine constants differ from the runtime's shared
+  `schemas/vex-model-schema.json`.
+
+Fix: align your `vex` and `vex-ai-runtime` versions; if you are developing
+locally, update whichever side is stale.
+
+See also: [`cli-reference.md`](cli-reference.md),
+[`troubleshooting.md`](troubleshooting.md), [`policy.md`](policy.md),
+[`deploy.md`](deploy.md), [`eval.md`](eval.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,143 @@
+# Troubleshooting
+
+Failure modes grouped by surface. Not exhaustive — this page lists the
+failure shapes most likely to hit a new user. See
+[`cli-reference.md`](cli-reference.md) for flag semantics and
+[`doctor.md`](doctor.md) for a per-check readiness guide.
+
+## vex init
+
+### "The requested interpreter resolved to Python X, which is incompatible..."
+
+Fix: pass `--python 3.12` or patch `requires-python` in the scaffolded
+`pyproject.toml`. Since #21, the scaffold normalizes `requires-python` to
+`>=3.11` and pins `.python-version` to `3.12` automatically unless you
+override with `--python`.
+
+### "uv: command not found"
+
+Fix: install `uv` via https://docs.astral.sh/uv/getting-started/installation/.
+`vex` shells out to `uv` for every verb — there is no fallback.
+
+### "vex init accepts only one path unless using a template..."
+
+Fix: `vex init <path>` for a plain project, or `vex init agent <path>` /
+`vex init inference-api <path>` for an AI template. A bare
+`vex init agent foo bar` is rejected with exit `2`.
+
+## vex dev
+
+### "watchfiles not installed" and dev runs without hot reload
+
+Fix: `uv sync --extra agent` — `watchfiles` ships as part of the PydanticAI
+install tree. `vex dev` detects the missing import, prints a notice, and
+falls back to running the dev command once.
+
+### Banner says "provider=ollama" but ollama is not on PATH
+
+Fix: install ollama from https://ollama.com, or export `OPENAI_API_KEY` /
+`ANTHROPIC_API_KEY`. The banner is produced by `resolve_dev_provider`: any
+hosted key flips the resolved provider; otherwise it defaults to `ollama`.
+
+### "vex dev requires [tool.vex.scripts].dev in pyproject.toml"
+
+Fix: add a `dev` alias under `[tool.vex.scripts]`, for example:
+
+```toml
+[tool.vex.scripts]
+dev = "python -m myapp.main"
+```
+
+Exit code: `2`.
+
+## vex eval
+
+### "The executable 'inspect-ai' was not found."
+
+Fix: the CLI entrypoint is `inspect`, not `inspect-ai`. `vex` already uses
+`uvx --from inspect-ai inspect` internally; this error means your shell PATH
+found stale `inspect-ai` machinery. Either remove the stale binary or rely
+on `uvx` (install `uv`).
+
+### "promptfooconfig.yaml present but I want the harness"
+
+Fix: `--adapter harness` (or `[tool.vex.eval].adapter = "harness"`). The
+deprecated `--no-promptfoo` flag still works but prints a deprecation
+warning.
+
+### Dataset parsing: "0 rows, N invalid JSON"
+
+Fix: validate with
+`python -c "import json; [json.loads(l) for l in open('evals/datasets/cases.jsonl')]"`.
+Each line must be a standalone JSON object with at least an `input` field.
+Empty lines are ignored.
+
+### `--min-pass-rate` always fails
+
+Fix: the value is a fraction in `[0.0, 1.0]`, not a percent. `0.9` means
+90 %. Values outside that range exit with code `2`.
+
+### "inspect adapter timed out after 300s"
+
+Fix: raise `--timeout` (seconds). Default is `300.0`; exceeding it returns
+exit code `124`.
+
+## vex deploy
+
+### "Preflight reported N issue(s); aborting."
+
+Fix: run `vex deploy check --for <target>` to see which checks failed —
+missing env vars, missing vendor CLI, or a missing project profile. Address
+each WARN, then re-run. `--skip-preflight` is available but bypasses safety.
+
+### "${VEX_IMAGE_REPO} not bound" (via preflight)
+
+Fix: export the env var or add it to a `.env` file sourced before
+`vex deploy`. `vex doctor ai` also catches this via the deploy env var
+interpolation check.
+
+### gcloud / modal / docker not on PATH
+
+Fix: install the target's CLI. `vex doctor ai` surfaces this too.
+
+- Cloud Run requires `gcloud`; deploy aborts with exit `127` when it is
+  missing.
+- Modal requires `modal` plus `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`.
+- Docker requires `docker` or `podman` on PATH.
+
+### Cloud Run URL not captured
+
+Fix: the URL is parsed from `gcloud run deploy`'s stdout/stderr using the
+`*.run.app` pattern. When the match fails you still see
+`Deployed service <name> (no URL detected in gcloud output)` and exit `0`.
+Re-run with `--quiet` already set; confirm the service in the Cloud Console.
+
+## vex run --sandbox
+
+### "No sandbox backend available"
+
+Fix: install `docker` or `podman`. Alternatively, opt in to unsandboxed
+execution with `vex policy set unsafe_fallback true --type bool` — this
+is a warning-only fallback and is not recommended for production.
+
+### "echo hi: not found" inside the sandbox
+
+Fix: known bug pre-#4. Upgrade to `main`. Single-token quoted commands are
+now passed verbatim to `sh -c` inside the container, so
+`vex run --sandbox "echo hi"` works as expected.
+
+### Image pull taking forever
+
+Fix: `<backend> pull <image>` outside of `vex` to warm the cache — for
+example `docker pull python:3.12-slim`. `vex doctor ai` reports when the
+configured `sandbox_image` is not cached locally.
+
+### "Sandbox execution is disabled by policy (sandbox=false)"
+
+Fix: set `[tool.vex.policy].sandbox = true` in `pyproject.toml`, or
+`vex policy set sandbox true --type bool`. The CLI refuses to shell out to
+a sandbox backend when policy says sandboxing is off.
+
+See also: [`doctor.md`](doctor.md), [`policy.md`](policy.md),
+[`eval.md`](eval.md), [`deploy.md`](deploy.md),
+[`cli-reference.md`](cli-reference.md).


### PR DESCRIPTION
## Summary

Lands three of the five docs pages deferred in #26 / tracked in #35. Pure
docs, no code changes.

## Files

- **`docs/cli-reference.md`** — verb-by-verb argparse reference grouped
  into **AI workflow verbs** (`init`, `dev`, `eval`, `deploy`,
  `deploy check`, `policy`, `run`, `package-model`,
  `schema validate-model`, `doctor`, `benchmark`) and **uv passthroughs**
  (`add` / `remove` / `sync` / `lock`, `test` / `lint` / `format` /
  `typecheck`, `python`, `build` / `publish`, `tool`). Per verb: one-line
  purpose, full flag list with types and defaults, exit codes, config
  sources, one short example. Deep content delegated to `policy.md`,
  `eval.md`, `deploy.md`.
- **`docs/doctor.md`** — one subsection per check in `doctor_checks`,
  split into `vex doctor` base scope and `vex doctor ai` additive scope
  (policy, deploy profile, runtime path, sandbox backend + image cache,
  hosted providers, ollama fallback, `.env.example` keys, observability,
  eval dataset shape, deploy env var interpolation, schema drift). Every
  WARN/ERR line has a one-liner `Fix:`.
- **`docs/troubleshooting.md`** — top failure modes per surface
  (`vex init`, `vex dev`, `vex eval`, `vex deploy`, `vex run --sandbox`).
  Not a comprehensive FAQ; tuned for the common real failure shapes.

## Out-of-scope follow-ups

- `docs/templates.md`
- `docs/faq.md`
- `docs/runtime.md`
- `docs/release.md`

## Test plan

- [x] Every flag and env var mentioned traced back to `src/vex/cli.py`
- [x] All intra-docs cross-links resolve against current `main`
- [x] No changes to `docs/README.md` or root `README.md`
- [x] Style matches the existing `docs/*.md` pages (declarative, short,
  no emojis)
- [ ] Render on GitHub looks right

Closes #35.