### PR TITLE
polish: vex doctor ai runtime check is soft for scaffolded projects

### DIFF
--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -460,6 +460,7 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
             lines.append("WARN missing deploy.targets.toml default profile")
 
         runtime_root = resolve_runtime_root(root)
+        runtime_override = os.environ.get("VEX_AI_RUNTIME_PATH")
         if runtime_root is not None:
             lines.append(f"OK  runtime path resolved to {runtime_root}")
             schema_path = runtime_root / "schemas" / "vex-model-schema.json"
@@ -468,9 +469,15 @@ def doctor_checks(root: Path, scope: str | None = None) -> tuple[int, list[str]]
             else:
                 issues += 1
                 lines.append("WARN runtime schema file missing")
-        else:
+        elif runtime_override:
             issues += 1
-            lines.append("WARN runtime path not resolved (set VEX_AI_RUNTIME_PATH if needed)")
+            lines.append(
+                f"WARN VEX_AI_RUNTIME_PATH={runtime_override} does not exist"
+            )
+        else:
+            lines.append(
+                "INFO runtime path not resolved; set VEX_AI_RUNTIME_PATH if you vendored the runtime"
+            )
 
         if bool(policy.get("sandbox", True)):
             backend = sandbox_backend(policy)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -649,6 +649,82 @@ class CliTests(unittest.TestCase):
             output,
         )
 
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-testkey"}, clear=False)
+    @patch("vex.cli.sandbox_image_cached", return_value=True)
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_runtime_missing_is_soft_for_scaffolded_project(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        os.environ.pop("VEX_AI_RUNTIME_PATH", None)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.env]\npath = \".venv\"\n\n"
+                "[tool.vex.scripts]\n"
+                'dev = "python -m demo.main"\n'
+                'benchmark = "python -m demo.benchmark"\n'
+                'eval = "python evals/run_eval.py --input {input}"\n\n'
+                "[tool.vex.policy]\n"
+                "sandbox = true\n"
+                'network = "deny"\n',
+                encoding="utf-8",
+            )
+            (root / "deploy.targets.toml").write_text(
+                "[profiles.default]\n"
+                'image = "ghcr.io/example/demo"\n',
+                encoding="utf-8",
+            )
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            (root / ".venv").mkdir()
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(code, 0)
+        self.assertIn("INFO runtime path not resolved", output)
+        self.assertNotIn("WARN runtime path", output)
+
+    @patch.dict(os.environ, {"VEX_AI_RUNTIME_PATH": "/definitely/not/a/real/path"}, clear=False)
+    @patch("vex.cli.sandbox_image_cached", return_value=True)
+    @patch("vex.cli.sandbox_backend", return_value="docker")
+    @patch("vex.cli.uv_bin", return_value="/usr/local/bin/uv")
+    def test_doctor_ai_runtime_missing_errors_when_env_var_set(
+        self,
+        _uv_bin: object,
+        _sandbox_backend: object,
+        _image_cached: object,
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n"
+                "[tool.vex]\nmanaged = true\n\n"
+                "[tool.vex.policy]\n"
+                "sandbox = true\n",
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["doctor", "ai"])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn(
+            "WARN VEX_AI_RUNTIME_PATH=/definitely/not/a/real/path does not exist",
+            output,
+        )
+
     @patch.dict(os.environ, {}, clear=True)
     @patch("vex.cli.shutil.which", return_value=None)
     @patch("vex.cli.sandbox_image_cached", return_value=None)


### PR DESCRIPTION
## Summary

Fresh `vex init agent demo && cd demo && vex doctor ai` now exits 0. The runtime-path check no longer bumps the issue count when the user hasn't explicitly opted in via `VEX_AI_RUNTIME_PATH` — the scaffolded `[tool.vex.ai].runtime` reference is aspirational for most users, so treat it as informational rather than a failure.

## Behavior matrix

| Condition | Before | After |
|---|---|---|
| Runtime found | OK line | OK line (unchanged) |
| Runtime not found, no env var | `WARN` + `issues += 1` | `INFO` (no issue bump) |
| Runtime not found, `VEX_AI_RUNTIME_PATH` set but bad | `WARN` + `issues += 1` | `WARN` + `issues += 1` with bad path echoed |

## Test plan
- [x] 86/86 tests pass (`PYTHONPATH=src python3 -m unittest tests.test_cli`)
- [x] Live `vex init agent demo && cd demo && vex doctor ai` exits 0
- [x] New `test_doctor_ai_runtime_missing_is_soft_for_scaffolded_project` covers the soft-INFO path
- [x] New `test_doctor_ai_runtime_missing_errors_when_env_var_set` covers the explicit opt-in failure path

Closes #37.