### PR TITLE
docs: add templates, faq, runtime, release pages (#46)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,3 +113,22 @@ space is higher-level and AI-specific:
 
 The better wedge for `vex` is an AI-native workflow layer that can later
 orchestrate `vex-ai-runtime` and other execution backends.
+
+## See also
+
+- [`product-boundary.md`](product-boundary.md) — what `vex`, `uv`, and
+  `vex-ai-runtime` each own.
+- [`roadmap.md`](roadmap.md) — shipped / next / later buckets.
+- [`cli-reference.md`](cli-reference.md) — per-verb flags and exit codes.
+- [`policy.md`](policy.md) — `[tool.vex.policy]` and `vex run --sandbox`.
+- [`eval.md`](eval.md) — adapter precedence and the `vex-eval/v1` schema.
+- [`deploy.md`](deploy.md) — `deploy.targets.toml` and target adapters.
+- [`doctor.md`](doctor.md) — readiness checks.
+- [`troubleshooting.md`](troubleshooting.md) — common failure modes.
+- [`templates.md`](templates.md) — what `vex init agent` /
+  `vex init inference-api` lay down.
+- [`faq.md`](faq.md) — positioning, mechanics, compatibility.
+- [`runtime.md`](runtime.md) — `vex-ai-runtime` and the `vex-model/v1`
+  manifest contract.
+- [`release.md`](release.md) — versioning, CI gate, changelog, and
+  deprecation policy.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,104 @@
+# FAQ
+
+Short answers to positioning, mechanics, and compatibility questions. See
+[`product-boundary.md`](product-boundary.md) for the long form on what vex
+owns vs delegates.
+
+## Positioning
+
+### Does vex replace uv?
+
+No. `uv` is a hard dependency. Every install, sync, lock, build, and publish
+verb shells out to `uv`; `vex` itself owns no resolver, lockfile, or build
+backend. See [`architecture.md`](architecture.md#non-goals).
+
+### Why not just a Makefile plus promptfoo?
+
+A Makefile encodes commands, not policy. `vex` composes command aliases
+(`[tool.vex.scripts]`) with sandbox semantics (`[tool.vex.policy]`), eval
+adapter resolution (`[tool.vex.eval]`), deploy profiles
+(`deploy.targets.toml`), and a shared model-artifact schema. The binding
+across those surfaces is the product — see
+[`policy.md`](policy.md) for the `[tool.vex.policy]` shape
+`vex run --sandbox` actually enforces.
+
+### Why PydanticAI as the default agent framework?
+
+Typed tool boundaries, `pydantic-settings`-shaped config, and first-class
+Logfire instrumentation line up with the rest of the vex surface. The
+`agent` scaffold wires `logfire.instrument_pydantic_ai()` when
+`LOGFIRE_TOKEN` is set; see
+[`templates.md`](templates.md#vex-init-agent-path).
+
+### Can I use LangGraph or Claude Agent SDK?
+
+Not yet via `vex init`. The `--framework` flag that adds `langgraph` and
+`claude-agent-sdk` scaffold variants is tracked in
+[issue #45](https://github.com/peaktwilight/vex/issues/45). Until it ships,
+either fork the PydanticAI scaffold or drop your framework of choice into a
+plain `uv init` project and add a `[tool.vex]` block by hand.
+
+### Why not the LangGraph CLI?
+
+LangGraph CLI is LangSmith-coupled and opinionated about graph authoring.
+`vex` is backend-neutral: no LangSmith lock-in, policy and sandbox are
+first-class, and the deploy targets (Docker, Cloud Run, Modal) are vendor-CLI
+wrappers — see [`deploy.md`](deploy.md).
+
+## Mechanics
+
+### How does `vex run --sandbox` differ from `docker run`?
+
+`vex run --sandbox` is a pre-configured `docker run` (or `podman run`) with
+`--cap-drop ALL`, `--read-only`, `--network <none|bridge>`,
+`--security-opt no-new-privileges`, memory and pids caps, and the project
+mounted read-only at `/workspace`. Every flag is driven by
+`[tool.vex.policy]` — see
+[`policy.md`](policy.md#what-vex-run---sandbox-actually-enforces) for the
+full argv shape.
+
+### What is `vex-ai-runtime` for?
+
+A Rust + PyO3 crate that owns native model artifact loading and
+`vex-model/v1` schema validation. `vex package-model` produces the
+manifest; `vex schema validate-model` and the runtime both consume it. See
+[`runtime.md`](runtime.md).
+
+### Is there a local-only mode?
+
+Yes. With no hosted provider key set, the agent scaffold's
+`resolve_provider()` returns `"ollama"` and `vex dev` prints
+`[vex dev] provider=ollama`. No network calls leave the box as long as
+`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are unset and the agent only touches
+local tools. `vex doctor ai` confirms the state (`OK  no hosted provider
+keys; ollama available on PATH (local fallback)`).
+
+## Compatibility
+
+### Which Python versions are supported?
+
+3.11 or newer. `vex init` normalizes the scaffolded `requires-python` to
+`>=3.11` and pins `.python-version` to `3.12` when `--python` is not
+passed. Both `vex` itself and `vex-ai-runtime` declare
+`requires-python = ">=3.11"`.
+
+### Which platforms are supported?
+
+macOS and Linux. The sandbox path assumes POSIX semantics (`sh -c`,
+container-native `--cap-drop`, `--read-only`, `--pids-limit`), so Windows
+is not tested and `vex run --sandbox` is unlikely to behave correctly
+there. Use WSL2 on Windows.
+
+### How is uv's version pinned?
+
+CI pins `astral-sh/setup-uv@v5` to a specific uv release
+(`version: "0.5.14"` at time of writing, in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). Local
+installations follow whatever the user installed via
+https://docs.astral.sh/uv/getting-started/installation/; `vex doctor`
+reports the resolved `uv` path.
+
+See also: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md), [`roadmap.md`](roadmap.md),
+[`templates.md`](templates.md), [`runtime.md`](runtime.md),
+[`troubleshooting.md`](troubleshooting.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,87 @@
+# Release
+
+How `vex` and `vex-ai-runtime` are versioned, gated, and changelogged. This
+is a policy doc, not a runbook — the mechanics live in
+[`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+## Versioning
+
+SemVer, with a pre-1.0 relaxation:
+
+- While the project is on `0.x`, breaking changes are allowed on minor
+  version bumps. Every breaking change ships with release notes and, where
+  relevant, a migration entry in the upgrade guide.
+- After `1.0`, breaking changes only ship on major version bumps.
+- Patch versions are always non-breaking (bugfix / docs / dependency floor
+  adjustments).
+
+The `vex` CLI surface (flags, config keys, exit codes) and the
+`vex-model/v1` manifest contract are the two surfaces SemVer applies to.
+Internal function signatures in `src/vex/cli.py` are not stable.
+
+## CI release gate
+
+A release tag (`v*`) is only cut when every gate below is green on the
+commit being tagged:
+
+- **Unit** — `vex-tests` and `runtime-python-tests` jobs in
+  [`ci.yml`](../.github/workflows/ci.yml). Run on every push / PR.
+- **Integration** — `integration` job in the same workflow
+  (`VEX_RUN_INTEGRATION=1 uv run pytest tests/integration -m integration`).
+- **Runtime Rust** — `runtime-rust-tests` job
+  (`cargo test` inside `engine/vex-ai-runtime`).
+- **Contract CI** — tracked in
+  [issue #44](https://github.com/peaktwilight/vex/issues/44). Verifies that
+  `vex package-model` output still loads cleanly through the runtime's
+  `load_artifact_manifest`, and that `VEX_MODEL_SCHEMA_ID` /
+  `VEX_MODEL_SCHEMA_VERSION` in `src/vex/cli.py` match
+  `engine/vex-ai-runtime/schemas/vex-model-schema.json`. This gate becomes
+  exhaustive once #44 merges.
+- **Release-E2E** — a manual end-to-end run against a representative scaffold
+  (`vex init agent`, `vex eval`, `vex deploy check --for all`) on the tagged
+  commit. Triggered by hand on the tag before publishing the GitHub Release.
+
+[`release.yml`](../.github/workflows/release.yml) handles the build step on
+tag push: `python -m build` for `vex`, `maturin build --release` and
+`python -m build engine/vex-ai-runtime` for the runtime, then
+`softprops/action-gh-release` attaches the artifacts.
+
+## Changelog convention
+
+`CHANGELOG.md` at the repo root, in
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+`Unreleased` at the top, then a section per released version with date,
+grouped under `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and
+`Security`. Each entry links to the merged PR or closing issue.
+
+`CHANGELOG.md` is not yet present in the repo — adding it is a follow-up
+(see PR body).
+
+## Upgrade guide convention
+
+Breaking changes get a per-minor section in `docs/upgrading.md` with:
+
+- What changed on the CLI surface, config keys, or scaffold layout.
+- The deprecation warning shown on the previous minor (if any).
+- The migration command or edit needed to move a project forward.
+
+`docs/upgrading.md` is not yet present — adding it is a follow-up (see PR
+body).
+
+## Deprecation policy
+
+When a flag, config key, or manifest field is removed:
+
+1. The previous minor release ships a deprecation warning on every use of
+   the surface, plus a changelog entry under `Deprecated`.
+2. The next minor release removes the surface and logs the removal under
+   `Removed` with a pointer at the upgrade guide section.
+
+Removing a surface in the same release cycle it was deprecated in is not
+allowed. Existing deprecation warnings in `src/vex/cli.py` (for instance
+`--no-promptfoo`, see
+[`cli-reference.md`](cli-reference.md#vex-eval)) follow this pattern.
+
+See also: [`architecture.md`](architecture.md),
+[`cli-reference.md`](cli-reference.md), [`roadmap.md`](roadmap.md),
+[`runtime.md`](runtime.md).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,171 @@
+# Runtime
+
+`vex-ai-runtime` is the native-execution half of the vex product boundary.
+Where `vex` owns the AI workflow surface in Python, `vex-ai-runtime` owns
+secure model artifact loading and runtime policy. The two sides communicate
+through the shared `vex-model/v1` manifest contract.
+
+Repo layout under [`engine/vex-ai-runtime/`](../engine/vex-ai-runtime/):
+
+- `Cargo.toml` — Rust crate (`vex-ai-runtime`, `cdylib` + `rlib`).
+- `src/lib.rs` — PyO3 module `_core` with `runtime_info` and `healthcheck`
+  entry points.
+- `python/vex_ai_runtime/` — Python facade: `__init__.py` re-exports the
+  native functions (or Python fallbacks when the extension is not built),
+  and `artifacts.py` implements `ArtifactManifest` + `load_artifact_manifest`.
+- `schemas/vex-model-schema.json` — shared schema file consumed by both
+  `vex` and the runtime's validator.
+- `pyproject.toml` — `maturin` build backend, `module-name =
+  "vex_ai_runtime._core"`.
+
+## What it does today
+
+- Native model artifact loading. `load_artifact_manifest(root)` reads
+  `vex-model.json` from an artifact directory, validates every field, and
+  resolves the referenced model file relative to the artifact root.
+- `vex-model/v1` schema validation. The runtime rejects manifests whose
+  `schema`, `schema_version`, `runtime`, or `engine` values do not match
+  `schemas/vex-model-schema.json`.
+- Runtime policy enforcement on the load path. `model_path` must be
+  relative and must not escape the artifact directory; the referenced file
+  must exist; `sha256` (when present) must be a string. `engine` is pinned
+  to `onnxruntime` for the MVP.
+- A stable Python surface that keeps working without the native extension.
+  `healthcheck()` returns `"ok"` when built with `maturin`,
+  `"native-extension-unavailable"` otherwise; `NATIVE_AVAILABLE` is the
+  boolean flag to branch on.
+
+## The `vex-model/v1` schema
+
+Manifest shape (`vex-model.json` at the artifact root):
+
+```json
+{
+  "schema": "vex-model/v1",
+  "schema_version": "v1",
+  "runtime": "vex-ai-runtime",
+  "name": "encoder",
+  "engine": "onnxruntime",
+  "model_path": "models/encoder.onnx",
+  "sha256": "..."
+}
+```
+
+Field semantics:
+
+- `schema` — always `"vex-model/v1"`. Stamped from
+  `engine/vex-ai-runtime/schemas/vex-model-schema.json` when the runtime is
+  resolvable, else from the constant `VEX_MODEL_SCHEMA_ID` in `vex`. Drift
+  between the two sides is surfaced by `vex doctor ai` — see
+  [`doctor.md`](doctor.md#schema-drift).
+- `schema_version` — currently `"v1"`; reserved for breaking schema
+  evolution.
+- `runtime` — always `"vex-ai-runtime"` for this contract.
+- `name` — non-empty human-readable name. Defaults to the source file's
+  stem when `vex package-model` is called without `--name`.
+- `engine` — pinned to `"onnxruntime"` for v1. Additional engines are
+  deferred.
+- `model_path` — path to the model binary, relative to the artifact root.
+  Absolute paths and `..` segments are rejected.
+- `sha256` — optional hex digest of the source model. `vex package-model`
+  computes it with `hashlib.sha256` when `--sha256` is not passed.
+
+Producer: `vex package-model <model> [--out-dir build/model-artifact]
+[--name <n>] [--sha256 <hex>] [--skip-compat-check]` copies the model into
+`<out-dir>/models/` and writes `<out-dir>/vex-model.json`. Every stamped
+field comes from `load_shared_model_schema`, which prefers the runtime's
+schema file over the `vex` constants. See
+[`cli-reference.md`](cli-reference.md#vex-package-model).
+
+Consumer: `vex schema validate-model <artifact_dir> [--strict-runtime]`
+runs the same load path the runtime uses — it will refuse to approve an
+artifact the runtime would refuse to load. See
+[`cli-reference.md`](cli-reference.md#vex-schema-validate-model).
+
+## When you need the runtime
+
+- Serving a packaged model artifact at native speed from an
+  `inference-api` scaffold.
+- Validating an artifact's manifest against the same rules the runtime
+  will apply (`vex schema validate-model`).
+- Producing a manifest whose schema fields match a specific
+  `vex-ai-runtime` checkout — useful in CI when vex and the runtime are
+  versioned together.
+
+## When you don't
+
+- The `vex dev` loop on a scaffolded agent. PydanticAI calls out to a
+  hosted provider or ollama; the runtime is not on this path.
+- `vex eval` against any of the three adapters (`harness`, `promptfoo`,
+  `inspect`). Evals run the project's command under `uv run`, not through
+  the runtime.
+- Any of the deploy targets' scaffolds (`docker`, `cloud-run`, `modal`).
+  Deploy surface is the user's own `Dockerfile` / Modal app / Cloud Run
+  service; wiring in the runtime is optional.
+
+## Vendoring the runtime
+
+`vex` looks up the runtime in this order (see `resolve_runtime_root` in
+[`src/vex/cli.py`](../src/vex/cli.py)):
+
+1. `$VEX_AI_RUNTIME_PATH` when exported and pointing at an existing path.
+2. `<project>/engine/vex-ai-runtime/`
+3. `<project parent>/vex-ai-runtime/`
+4. `<project>/vex-ai-runtime/`
+5. `<project parent parent>/vex-ai-runtime/`
+6. `<project>/packages/vex-ai-runtime/`
+
+Example layouts:
+
+```
+# Sibling checkout
+workspace/
+├── my-agent/
+│   └── pyproject.toml
+└── vex-ai-runtime/
+    ├── schemas/vex-model-schema.json
+    └── ...
+
+# Vendored into the project
+my-agent/
+├── pyproject.toml
+└── packages/vex-ai-runtime/
+    └── schemas/vex-model-schema.json
+
+# Explicit override
+export VEX_AI_RUNTIME_PATH=/opt/vex-ai-runtime
+```
+
+`vex doctor ai` echoes the resolved path as
+`OK  runtime path resolved to <path>`, or warns when nothing is found. When
+the runtime is missing, `vex package-model` still works (it falls back to
+the `VEX_MODEL_SCHEMA_ID` / `VEX_MODEL_SCHEMA_VERSION` constants baked into
+`vex`), but schema drift cannot be detected.
+
+## Building from source
+
+Inside the monorepo:
+
+```bash
+# Rust core
+cargo test --manifest-path engine/vex-ai-runtime/Cargo.toml
+cargo build -p vex-ai-runtime --release
+
+# Python surface (pure Python, runs without the native extension)
+python3 -m unittest discover -s engine/vex-ai-runtime/tests
+
+# Native extension via maturin (PyO3 cdylib -> vex_ai_runtime._core)
+pip install maturin
+maturin develop --manifest-path engine/vex-ai-runtime/Cargo.toml
+```
+
+The `Makefile` targets `test-runtime-python` and `test-runtime-rust` wrap
+the first two invocations; `make test` runs the full `vex` + runtime
+matrix. Release builds (`maturin build`) are driven by
+[`.github/workflows/release.yml`](../.github/workflows/release.yml) on
+version tags.
+
+See also: [`architecture.md`](architecture.md),
+[`product-boundary.md`](product-boundary.md),
+[`cli-reference.md`](cli-reference.md), [`policy.md`](policy.md),
+[`doctor.md`](doctor.md).

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,186 @@
+# Templates
+
+A `vex` template is the scaffold that `vex init <template> <path>` lays down
+on top of `uv init`. Each template is a fixed tree of files plus a
+`[tool.vex]` block appended to `pyproject.toml` — the conventions are the
+product, not the individual files. Ground truth for every file emitted is
+`scaffold_agent_template` and `scaffold_inference_template` in
+[`src/vex/cli.py`](../src/vex/cli.py).
+
+Two templates ship today:
+
+- `agent` — PydanticAI-based chat / tool-use agent with typed settings and a
+  dataset-driven eval harness.
+- `inference-api` — FastAPI + uvicorn service with a `/healthz` endpoint
+  ready for `vex package-model` wiring.
+
+Both scaffolds install in package mode (`package-mode = true`, `uv init
+--package --build-backend hatch`) so `python -m <pkg>.main` resolves without
+`PYTHONPATH` tricks, normalize `requires-python` to `>=3.11`, and write
+`deploy.targets.toml` with `default` and `prod` profiles. Policy defaults
+(`[tool.vex.policy]`) are the same for both — see [`policy.md`](policy.md).
+
+## `vex init agent <path>`
+
+Tree:
+
+```
+<path>/
+├── .env.example
+├── .python-version
+├── deploy.targets.toml
+├── pyproject.toml
+├── prompts/
+│   └── system.md
+├── src/<pkg>/
+│   ├── __init__.py
+│   ├── agent.py
+│   ├── benchmark.py
+│   ├── eval.py
+│   ├── main.py
+│   └── settings.py
+├── evals/
+│   ├── run_eval.py
+│   └── datasets/
+│       ├── .gitkeep
+│       └── cases.jsonl
+└── tests/
+    └── test_smoke.py
+```
+
+Per file:
+
+- `src/<pkg>/settings.py` — `pydantic_settings.BaseSettings` subclass with a
+  `VEX_` env prefix, `.env` loader, and `resolve_provider()` /
+  `model_spec()` helpers. Picks `openai` when `OPENAI_API_KEY` is set,
+  `anthropic` when `ANTHROPIC_API_KEY` is set, falls back to `ollama`. This
+  file is the first thing to edit when adding a new provider knob.
+- `src/<pkg>/agent.py` — `build_agent(settings)` that constructs a
+  `pydantic_ai.Agent` from the resolved model spec, loads the system prompt
+  from `prompts/system.md`, and registers a single `lookup_faq` tool as a
+  placeholder. Add your tools here.
+- `src/<pkg>/main.py` — CLI entry point. Runs the agent with a prompt from
+  argv, prints the resolved provider / model banner, and wires
+  `logfire.instrument_pydantic_ai()` when `LOGFIRE_TOKEN` is exported.
+  `vex dev` invokes this module via `[tool.vex.scripts].dev`.
+- `src/<pkg>/benchmark.py` — minimal warmup-free latency sampler. Targeted
+  by `[tool.vex.scripts].benchmark` and re-run via `vex benchmark`.
+- `src/<pkg>/eval.py` — the package-local eval harness. Reads
+  `evals/datasets/cases.jsonl`, runs each case through `build_agent()`, and
+  prints pass/fail. Swap this out for an Inspect AI task or a promptfoo
+  config once you outgrow substring matching.
+- `prompts/system.md` — system prompt text. Plain markdown; not templated.
+- `evals/run_eval.py` — thin wrapper that `[tool.vex.scripts].eval` invokes
+  (`python evals/run_eval.py --input {input}`). Forwards to the package's
+  `eval.py`.
+- `evals/datasets/cases.jsonl` — seed dataset, one JSON object per line
+  (`input`, `expect_contains`). Schema documented in
+  [`eval.md`](eval.md#authoring-evalsdatasetscasesjsonl).
+- `.env.example` — commented-out provider keys and overrides (`VEX_PROVIDER`,
+  `VEX_OPENAI_MODEL`, `LOGFIRE_TOKEN`, `OTEL_EXPORTER_OTLP_ENDPOINT`). Copy
+  to `.env` and fill in.
+- `deploy.targets.toml` — see [`deploy.md`](deploy.md) for the schema.
+  `[profiles.default]` points at `ghcr.io/example/<pkg>` with a `<pkg>-agent`
+  service / app name; `[profiles.prod]` overrides the tag to `prod` and
+  enables `push`.
+- `pyproject.toml` — `[project.optional-dependencies].agent` pins
+  `pydantic-ai`, `pydantic-settings`, `httpx`, `tenacity`. `eval` extra adds
+  `deepeval` and `ragas`; `observability` adds `logfire`. Install with
+  `uv sync --extra agent`.
+- `tests/test_smoke.py` — placeholder `assert True` so `vex test` passes on
+  a fresh scaffold.
+
+User-customizable: every file under `src/<pkg>/`, `prompts/`, `evals/`, plus
+`.env.example`. `deploy.targets.toml` and the `[tool.vex.*]` blocks are
+intended to be edited in place.
+
+## `vex init inference-api <path>`
+
+Tree:
+
+```
+<path>/
+├── .python-version
+├── deploy.targets.toml
+├── pyproject.toml
+├── src/<pkg>/
+│   ├── __init__.py
+│   ├── api.py
+│   ├── benchmark.py
+│   └── eval.py
+├── evals/
+│   ├── run_eval.py
+│   └── datasets/
+│       ├── .gitkeep
+│       └── cases.jsonl
+└── tests/
+    └── test_smoke.py
+```
+
+Per file:
+
+- `src/<pkg>/api.py` — FastAPI `app` with a `/healthz` endpoint and a
+  `uvicorn.run` block guarded by `__name__ == "__main__"`. `vex dev`
+  invokes this module via `[tool.vex.scripts].dev`
+  (`python -m <pkg>.api`). Add your `/predict` handler here.
+- `src/<pkg>/benchmark.py` — stub benchmark for `vex benchmark` to reach
+  before you wire real latency measurement.
+- `src/<pkg>/eval.py` — argparse-driven stub that reads
+  `evals/datasets/cases.jsonl` and prints the case count. Replace with a
+  real HTTP-driven eval once the `/predict` handler exists.
+- `evals/run_eval.py` — standalone (not a package wrapper this time);
+  targeted by `[tool.vex.scripts].eval`.
+- `evals/datasets/cases.jsonl` — single-case seed dataset.
+- `deploy.targets.toml` — `<pkg>-api` service and app names, otherwise the
+  same shape as the agent scaffold.
+- `pyproject.toml` — `[project.optional-dependencies].api` pins `fastapi`,
+  `uvicorn[standard]`, `pydantic-settings`, `httpx`, `tenacity`. `eval`
+  extra same as the agent template. Install with `uv sync --extra api`.
+- `tests/test_smoke.py` — placeholder smoke test.
+
+User-customizable: `api.py` (the whole point of the template), `eval.py`,
+the dataset, and the deploy profile. The other files are scaffold scaffolding.
+
+Pair with [`vex package-model`](cli-reference.md#vex-package-model) and
+[`vex schema validate-model`](cli-reference.md#vex-schema-validate-model)
+when the API is serving a packaged `vex-model/v1` artifact — see
+[`runtime.md`](runtime.md).
+
+## Framework variants
+
+The current `agent` template hardcodes PydanticAI. The `--framework` flag is
+not yet on `main`; adding LangGraph and Claude Agent SDK variants is tracked
+in [issue #45](https://github.com/peaktwilight/vex/issues/45). Once it lands,
+this section will cover all three side by side. For now:
+
+- PydanticAI is the default because its typed tool boundary, `RunContext`
+  usage pattern, and native Logfire hook match the rest of the vex surface.
+- LangGraph and Claude Agent SDK will be opt-in via `--framework langgraph`
+  and `--framework claude-agent-sdk` once #45 ships. Pick your framework at
+  `vex init` time; the rest of the scaffold (`settings.py`, `eval.py`,
+  `deploy.targets.toml`, policy defaults) will stay the same shape.
+
+## Customizing the scaffold
+
+The templates are emitted by a handful of helper functions, not loaded from
+template files on disk. To change what `vex init` lays down:
+
+- `scaffold_agent_template(root, package_name)` —
+  [`src/vex/cli.py`](../src/vex/cli.py) — controls every file under the
+  agent tree.
+- `scaffold_inference_template(root, package_name)` —
+  same file — controls the inference-api tree.
+- `append_vex_config(root, package_mode, template, package_name)` —
+  controls the `[tool.vex.*]` blocks and the optional-dependency table.
+- `scaffold_deploy_targets(root, package_name, template)` —
+  controls `deploy.targets.toml`.
+
+For one-off edits, scaffold a project with `vex init` and edit the output.
+To fork the scaffold as a starting point, copy the generated tree into
+your own template repo and add the files you need — vex does not re-read
+its templates after init, so a forked tree stays a plain uv project the
+rest of the way.
+
+See also: [`policy.md`](policy.md), [`eval.md`](eval.md),
+[`deploy.md`](deploy.md), [`cli-reference.md`](cli-reference.md),
+[`runtime.md`](runtime.md).


### PR DESCRIPTION
## Summary

Closes the remaining docs backlog from #26 / #35 by adding the four pages called out in #46.

### `docs/templates.md`
Full tree walkthrough of `vex init agent` and `vex init inference-api` (per-file purpose, user-customizable vs scaffold-level files). Framework-variants section notes that `--framework` is tracked in #45 and is **not yet on `main`** — so this page documents the PydanticAI scaffold in full with a short forward-compat pointer. When #45 lands, the variants section can be expanded to cover langgraph and claude-agent-sdk side by side.

### `docs/faq.md`
Three sections — positioning, mechanics, compatibility — 2-4 sentence answers each. Covers: uv as hard dep, why not Makefile, PydanticAI default, LangGraph/Claude Agent SDK status (points at #45), LangGraph CLI positioning, sandbox vs plain docker run, `vex-ai-runtime` role, local-only mode, Python 3.11+, macOS/Linux only, uv pinning in CI.

### `docs/runtime.md`
Primer on `vex-ai-runtime`: what the Rust + PyO3 crate is, what it does today (manifest loading, schema validation, load-path policy), the `vex-model/v1` schema, when you need it, how `resolve_runtime_root` searches (env var + five path candidates), example vendored layouts, and `cargo` / `maturin` build invocations. Verified every field and constant against `engine/vex-ai-runtime/python/vex_ai_runtime/artifacts.py` and `src/vex/cli.py`.

### `docs/release.md`
Versioning (SemVer with 0.x breaking-on-minor relaxation), CI gate listing every existing workflow job plus a note that the gate becomes exhaustive once contract CI lands in #44, changelog convention (Keep-a-Changelog, `CHANGELOG.md` not yet created — follow-up), upgrade guide convention (`docs/upgrading.md` not yet created — follow-up), deprecation policy (one minor of warnings before removal).

### `docs/architecture.md`
Added a `See also` section at the end so the four new pages (plus the existing docs) are discoverable from the canonical index page.

## State at rebase time

Rebased against `main` at `07b722b`. `grep -n "claude_agent_sdk\|langgraph" src/vex/cli.py` returns nothing, i.e. **#45 has not landed** — so `docs/templates.md` documents the PydanticAI scaffold only and defers the three-way comparison table to a follow-up once #45 ships.

## Follow-ups (out of scope here)

- Create `CHANGELOG.md` at repo root (Keep-a-Changelog format) — called out in `docs/release.md`.
- Create `docs/upgrading.md` with per-minor sections for breaking changes — called out in `docs/release.md`.
- Extend `docs/templates.md` framework-variants section once #45 lands, with a comparison table and per-framework dep lists.

## Constraints checked

- Every flag / command / config key / env var referenced exists in `src/vex/cli.py` (spot-checked `--framework` returns no match; `VEX_AI_RUNTIME_PATH`, `VEX_MODEL_SCHEMA_ID`, `DEFAULT_SCAFFOLD_PYTHON`, `VEX_PROVIDER`, `LOGFIRE_TOKEN`, etc. all verified).
- Every cross-link is to a real file; section-anchor links match GitHub's slug rules for the target headers.
- No code changes, no scaffold changes, no README changes. Pure docs.

## Test plan

- [ ] `docs/templates.md` — verify file tree matches `scaffold_agent_template` / `scaffold_inference_template` output of a fresh `vex init agent` and `vex init inference-api`
- [ ] `docs/faq.md` — verify every cited flag / config key resolves via `vex --help` and `cli-reference.md`
- [ ] `docs/runtime.md` — verify the search-order list matches `resolve_runtime_root` in `src/vex/cli.py`, and the schema fields match `engine/vex-ai-runtime/schemas/vex-model-schema.json`
- [ ] `docs/release.md` — verify every referenced workflow file name resolves under `.github/workflows/`
- [ ] `docs/architecture.md` — verify the new `See also` list has no 404s

Closes #46.

none