### PR TITLE
feat: vex export and vex import — portable .vex agent artifacts (#42)

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,176 @@
+# Portable `.vex` artifacts
+
+`vex export` and `vex import` turn a vex-managed project into a single
+self-describing file. The README's headline — "portable execution
+contract" — is literal here: the policy, the scaffold source, the resolved
+deps (`uv.lock` hash), and any model manifests are all bundled together so
+the exact same bytes can be imported on another machine, reviewed, and then
+run, evaluated, or deployed under the same `[tool.vex.policy]`.
+
+## File layout
+
+A `.vex` file is a gzipped POSIX tarball. The first member is always
+`manifest.json`, followed by every tracked project file in sorted path
+order.
+
+```
+artifact.vex (gzip)
+├── manifest.json
+├── .env.example
+├── .gitignore
+├── pyproject.toml
+├── src/<pkg>/__init__.py
+├── src/<pkg>/main.py
+├── uv.lock
+└── dist/<model>/vex-model.json   # if --include-models
+```
+
+## Manifest schema — `vex-artifact/v1`
+
+```json
+{
+  "schema": "vex-artifact/v1",
+  "name": "support-bot",
+  "version": "0.3.2",
+  "created_at": "2026-04-17T00:00:00Z",
+  "python_requires": ">=3.11",
+  "entry_module": "support_bot.main",
+  "policy": {
+    "sandbox": true,
+    "network": "deny",
+    "filesystem": "project",
+    "sandbox_backend": "auto",
+    "sandbox_image": "python:3.12-slim",
+    "sandbox_memory_mb": 1024,
+    "sandbox_pids_limit": 128,
+    "unsafe_fallback": false
+  },
+  "adapters": {
+    "eval": "inspect",
+    "runtime": "vex-ai-runtime",
+    "framework": "pydantic-ai",
+    "template": "agent"
+  },
+  "files": [
+    { "path": "pyproject.toml", "sha256": "..." },
+    { "path": "src/support_bot/main.py", "sha256": "..." }
+  ],
+  "models": [
+    {
+      "path": "dist/classifier/models/classifier.onnx",
+      "sha256": "...",
+      "engine": "onnxruntime",
+      "name": "classifier"
+    }
+  ],
+  "locks": { "uv.lock": "sha256:..." }
+}
+```
+
+Field meanings:
+
+- `schema` — exact string `vex-artifact/v1`. Anything else is rejected by
+  `vex import`.
+- `name` / `version` / `python_requires` — copied verbatim from `[project]`
+  in `pyproject.toml`.
+- `entry_module` — best-effort `<snake(name)>.main` so `vex deploy` and
+  `vex run` can resolve a default entrypoint without user input.
+- `policy` — snapshot of the effective `load_vex_policy(root)` value
+  (merged from `[tool.vex.policy]` + `.vex/policy.json`).
+- `adapters` — copied from `[tool.vex.ai]` (`template`, `runtime`,
+  `framework`) and `[tool.vex.eval]` (`adapter`). Keys are omitted when
+  unset.
+- `files` — sorted, path-relative-to-root with a SHA-256 over the file
+  contents.
+- `models` — one entry per `dist/<name>/vex-model.json` referenced model
+  file. Omitted with `--no-include-models`.
+- `locks` — currently `uv.lock` with a `sha256:<hex>` string, empty when
+  no lockfile is present.
+
+## `vex export`
+
+Flags:
+
+- `--out <path>` — artifact destination. Default:
+  `dist/<name>-<version>.vex` under the project root.
+- `--include-models` / `--no-include-models` — walk `dist/*/vex-model.json`
+  and inline the referenced model files. Default: include.
+- `--include-venv` / `--no-include-venv` — override the `.venv/` default
+  exclude. Default: exclude.
+- `--dry-run` — print the manifest to stdout, do not write the tarball.
+  Exit 0.
+- `--exclude <glob>` — repeatable glob (matched against the relative path)
+  for project-specific skips.
+
+Default excludes (applied on top of `.gitignore`):
+
+```
+.venv/  __pycache__/  .pytest_cache/  .mypy_cache/
+.ruff_cache/  .git/  dist/  artifacts/
+node_modules/  *.pyc  .DS_Store  .env
+```
+
+`.env.example` is explicitly allowed so the scaffold's documented env keys
+stay with the artifact.
+
+## Determinism guarantee
+
+Two exports of the same tree (no file contents changed) produce **byte-
+identical** `.vex` output. The writer:
+
+- Walks the tree with sorted directory entries.
+- Uses `USTAR_FORMAT` and sets `tarinfo.mtime = 0`, `uid = gid = 0`,
+  `uname = gname = ""`, file mode `0644`, directory mode `0755`.
+- Streams through `gzip.GzipFile(fileobj=..., mtime=0)` so the gzip header
+  carries no timestamp.
+- Seeds `manifest.created_at` from the newest `mtime` in the included set
+  rather than wall-clock `now()`.
+
+This makes `.vex` files reviewable and diff-able: a reviewer can re-export
+a committed branch locally and compare SHA-256 digests against the shipped
+artifact.
+
+## `vex import`
+
+```
+vex import <artifact.vex> [--dest <path>] [--force]
+```
+
+1. Opens the tarball and reads `manifest.json` first.
+2. Refuses to write when the destination directory is non-empty (override
+   with `--force`).
+3. Extracts every file listed under `manifest.files`, recomputing the
+   SHA-256 on the fly.
+4. Any file whose SHA-256 does not match the manifest fails the import
+   with exit code 2. `--force` downgrades this to `WARN` and continues.
+5. On success, prints a summary:
+
+```
+Unpacked support-bot v0.3.2 to <dest>. policy.sandbox=true network=deny entry=support_bot.main. Next: cd <dest> && vex doctor ai
+```
+
+Paths that try to escape the destination (`../`, absolute paths) are
+rejected unconditionally.
+
+## How model files are collected
+
+`vex export` does not re-discover model files from scratch. It looks for
+`dist/<name>/vex-model.json` manifests (produced by `vex package-model`)
+and copies the `model_path` entries into the artifact. This keeps the
+runtime's model-compatibility contract — `vex-model/v1`, enforced by
+`vex-ai-runtime` — intact end-to-end.
+
+To include a model, run `vex package-model <model>` first, then
+`vex export`.
+
+## Follow-ups (out of scope for this release)
+
+- `vex deploy <target> --from artifact.vex` — deploy straight from a `.vex`
+  without unpacking into a working tree.
+- `vex run --from artifact.vex --sandbox` — execute an artifact directly
+  under the declared policy.
+- Signing with a cosign key and a server-side verifier.
+- Remote artifact registry / pull from URL.
+
+See also: [`cli-reference.md`](cli-reference.md),
+[`policy.md`](policy.md), [`deploy.md`](deploy.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -394,6 +394,62 @@ Example:
 vex benchmark --runs 20 --warmup 3 --command "python -m app.bench"
 ```
 
+### `vex export`
+
+Bundle a vex-managed project into a portable `.vex` artifact (gzipped
+tarball). See [`artifacts.md`](artifacts.md) for the manifest schema and
+the determinism guarantee.
+
+Flags:
+
+- `--out <path>` — artifact destination (default
+  `dist/<name>-<version>.vex`).
+- `--include-models` / `--no-include-models` — walk `dist/*/vex-model.json`
+  and inline the referenced model files (default: include).
+- `--include-venv` / `--no-include-venv` — override the default `.venv/`
+  exclude (default: exclude).
+- `--dry-run` — print the manifest to stdout without writing a tarball.
+- `--exclude <glob>` — repeatable glob against the relative path.
+
+Exit codes:
+
+- `0` — artifact written (or dry-run printed).
+- `2` — invalid arguments.
+
+Example:
+
+```bash
+vex export --out dist/support-bot-0.3.2.vex
+```
+
+### `vex import`
+
+Unpack a `.vex` artifact into a fresh project directory, verifying every
+file's SHA-256 against the manifest.
+
+Positional:
+
+- `artifact` — path to the `.vex` file.
+
+Flags:
+
+- `--dest <path>` — destination directory (default: current dir + the
+  artifact stem).
+- `--force` — downgrade SHA mismatches to a `WARN` and allow overwriting a
+  non-empty destination.
+
+Exit codes:
+
+- `0` — artifact unpacked cleanly.
+- `2` — SHA mismatch, missing manifest, refused overwrite, or invalid
+  archive.
+
+Example:
+
+```bash
+vex import dist/support-bot-0.3.2.vex --dest /tmp/support-bot
+```
+
 ## uv passthroughs
 
 These verbs delegate directly to `uv`. They exist so the workflow stays

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -155,4 +155,5 @@ flag will be the opt-out path.
 
 See also: [`architecture.md`](architecture.md),
 [`product-boundary.md`](product-boundary.md), [`policy.md`](policy.md),
-[`eval.md`](eval.md).
+[`eval.md`](eval.md), [`artifacts.md`](artifacts.md) (portable `.vex`
+export/import; `--from artifact.vex` on deploy is a planned follow-up).

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -147,4 +147,6 @@ policies on the inference path — see
 `vex-model/v1` manifest contract.
 
 See also: [`architecture.md`](architecture.md),
-[`product-boundary.md`](product-boundary.md), [`deploy.md`](deploy.md).
+[`product-boundary.md`](product-boundary.md), [`deploy.md`](deploy.md),
+[`artifacts.md`](artifacts.md) (the policy snapshot travels inside every
+`.vex` export).

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
+import fnmatch
+import gzip
 import hashlib
+import io
 import json
 import os
 import re
@@ -10,6 +14,7 @@ import shutil
 import statistics
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import tomllib
@@ -28,6 +33,8 @@ COMMAND_HELP = {
     "policy": "Inspect AI execution policy configuration",
     "package-model": "Create a packaged model artifact manifest",
     "schema": "Validate Vex schema artifacts",
+    "export": "Bundle the project into a portable .vex artifact",
+    "import": "Unpack a portable .vex artifact into a project directory",
     "add": "Add dependencies and sync the environment",
     "remove": "Remove dependencies and sync the environment",
     "sync": "Make the environment match the lockfile",
@@ -2957,6 +2964,556 @@ def package_model(root: Path, model_path: Path, out_dir: Path, name: str | None,
     return manifest_path
 
 
+# ---------------------------------------------------------------------------
+# vex export / vex import — portable .vex agent artifacts
+# ---------------------------------------------------------------------------
+
+VEX_ARTIFACT_SCHEMA = "vex-artifact/v1"
+VEX_ARTIFACT_MANIFEST_NAME = "manifest.json"
+
+# Paths (directories are matched by a trailing `/` or by path prefix).
+DEFAULT_EXPORT_EXCLUDES: tuple[str, ...] = (
+    ".venv/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".git/",
+    "dist/",
+    "artifacts/",
+    "node_modules/",
+    "*.pyc",
+    ".DS_Store",
+    ".env",
+)
+
+
+class _GitignoreMatcher:
+    """Minimal gitignore-style matcher. Stdlib-only, ~30-50 lines.
+
+    Supports line-by-line patterns from one or more `.gitignore` files
+    interpreted relative to their parent directory. Handles:
+
+    - blank lines and `#` comments (ignored)
+    - leading `!` for negation
+    - leading `/` to anchor to the gitignore's directory
+    - trailing `/` to match directories only
+    - glob metacharacters via `fnmatch` on each path segment
+
+    This is intentionally a subset of full gitignore semantics (no `**`,
+    no character classes beyond fnmatch). Good enough for the default
+    project trees we export; `--exclude` covers the long tail.
+    """
+
+    def __init__(self, root: Path):
+        self._root = root
+        # Each rule: (base_rel_posix, pattern, is_negation, dir_only, anchored)
+        self._rules: list[tuple[str, str, bool, bool, bool]] = []
+        # Seeded with the project-root .gitignore; subdir .gitignores load lazily.
+        gi = root / ".gitignore"
+        if gi.is_file():
+            self._load(gi, base_rel="")
+
+    def _load(self, path: Path, base_rel: str) -> None:
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return
+        for raw in content.splitlines():
+            line = raw.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            negation = False
+            if line.startswith("!"):
+                negation = True
+                line = line[1:]
+            anchored = False
+            if line.startswith("/"):
+                anchored = True
+                line = line[1:]
+            dir_only = False
+            if line.endswith("/"):
+                dir_only = True
+                line = line[:-1]
+            if not line:
+                continue
+            self._rules.append((base_rel, line, negation, dir_only, anchored))
+
+    def match(self, rel_posix: str, is_dir: bool) -> bool:
+        """Return True when `rel_posix` should be ignored."""
+        ignored = False
+        for base_rel, pattern, negation, dir_only, anchored in self._rules:
+            if dir_only and not is_dir:
+                continue
+            # Limit the rule's scope to its own directory.
+            if base_rel:
+                if not (rel_posix == base_rel or rel_posix.startswith(base_rel + "/")):
+                    continue
+                candidate = rel_posix[len(base_rel) + 1 :] if rel_posix != base_rel else ""
+            else:
+                candidate = rel_posix
+            if not candidate:
+                continue
+            if anchored or "/" in pattern:
+                if fnmatch.fnmatchcase(candidate, pattern):
+                    ignored = not negation
+                    continue
+                # Also match as a prefix for directory patterns like "src/foo".
+                if fnmatch.fnmatchcase(candidate, pattern + "/*"):
+                    ignored = not negation
+                    continue
+            else:
+                # Unanchored: match any segment of the path.
+                segments = candidate.split("/")
+                if any(fnmatch.fnmatchcase(seg, pattern) for seg in segments):
+                    ignored = not negation
+        return ignored
+
+
+def _match_default_exclude(rel_posix: str, is_dir: bool) -> bool:
+    segments = rel_posix.split("/")
+    for pattern in DEFAULT_EXPORT_EXCLUDES:
+        if pattern.endswith("/"):
+            name = pattern[:-1]
+            if any(seg == name for seg in segments):
+                return True
+        elif pattern == ".env":
+            # Exact match on basename, but .env.example is explicitly allowed.
+            if segments[-1] == ".env":
+                return True
+        elif "*" in pattern or "?" in pattern or "[" in pattern:
+            if any(fnmatch.fnmatchcase(seg, pattern) for seg in segments):
+                return True
+        else:
+            if segments[-1] == pattern:
+                return True
+    return False
+
+
+def _match_user_excludes(rel_posix: str, patterns: Sequence[str]) -> bool:
+    for pattern in patterns:
+        if fnmatch.fnmatchcase(rel_posix, pattern):
+            return True
+        # Also match directory prefixes: "src/*" should hit "src/foo/bar.py".
+        if fnmatch.fnmatchcase(rel_posix, pattern.rstrip("/") + "/*"):
+            return True
+    return False
+
+
+def collect_export_files(
+    root: Path,
+    *,
+    include_venv: bool,
+    extra_excludes: Sequence[str] = (),
+) -> list[Path]:
+    """Walk `root` and return included files (sorted, relative paths as `Path`)."""
+    gi = _GitignoreMatcher(root)
+    collected: list[Path] = []
+
+    def _is_excluded(rel_posix: str, is_dir: bool) -> bool:
+        if rel_posix in {".git", ".git/"}:
+            return True
+        if _match_default_exclude(rel_posix, is_dir):
+            # The --include-venv toggle lets users override the default .venv skip.
+            if include_venv and rel_posix.split("/")[0] == ".venv":
+                return False
+            return True
+        if _match_user_excludes(rel_posix, extra_excludes):
+            return True
+        if gi.match(rel_posix, is_dir):
+            return True
+        return False
+
+    # Deterministic walk: sort entries per directory.
+    stack: list[Path] = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir(), key=lambda p: p.name)
+        except OSError:
+            continue
+        for entry in entries:
+            rel = entry.relative_to(root)
+            rel_posix = rel.as_posix()
+            if entry.is_symlink():
+                # Skip symlinks entirely; a reproducible tarball cannot
+                # round-trip them safely across platforms.
+                continue
+            if entry.is_dir():
+                if _is_excluded(rel_posix, True):
+                    continue
+                stack.append(entry)
+                continue
+            if entry.is_file():
+                if _is_excluded(rel_posix, False):
+                    continue
+                collected.append(rel)
+    collected.sort(key=lambda p: p.as_posix())
+    return collected
+
+
+def collect_export_model_manifests(root: Path) -> list[dict[str, Any]]:
+    """Find dist/<name>/vex-model.json files and read their summary fields."""
+    dist = root / "dist"
+    results: list[dict[str, Any]] = []
+    if not dist.is_dir():
+        return results
+    for manifest_path in sorted(dist.glob("*/vex-model.json")):
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        model_rel = data.get("model_path")
+        if not isinstance(model_rel, str):
+            continue
+        model_file = manifest_path.parent / model_rel
+        try:
+            model_rel_to_root = model_file.resolve().relative_to(root.resolve()).as_posix()
+        except (OSError, ValueError):
+            model_rel_to_root = (manifest_path.parent / model_rel).as_posix()
+        sha = data.get("sha256") if isinstance(data.get("sha256"), str) else None
+        if sha is None and model_file.is_file():
+            sha = compute_sha256(model_file)
+        entry: dict[str, Any] = {
+            "path": model_rel_to_root,
+            "sha256": sha or "",
+            "engine": str(data.get("engine", "")),
+        }
+        if "name" in data:
+            entry["name"] = str(data["name"])
+        results.append(entry)
+    return results
+
+
+def _derive_entry_module(project_name: str) -> str:
+    snake = re.sub(r"[^A-Za-z0-9]+", "_", project_name).strip("_").lower()
+    return f"{snake or 'app'}.main"
+
+
+def build_vex_artifact_manifest(
+    root: Path,
+    policy: dict[str, Any],
+    files: Sequence[Path],
+    models: Sequence[dict[str, Any]],
+    *,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the `manifest.json` dict for an exported artifact.
+
+    Pulled out so tests can exercise the manifest shape directly without
+    driving the full tarball writer.
+    """
+    pyproject = load_pyproject(root)
+    project = pyproject.get("project", {}) if isinstance(pyproject, dict) else {}
+    name = str(project.get("name", "")) or root.name
+    version = str(project.get("version", "0.0.0"))
+    python_requires = str(project.get("requires-python", ""))
+
+    tool_vex = pyproject.get("tool", {}).get("vex", {}) if isinstance(pyproject, dict) else {}
+    ai_cfg = tool_vex.get("ai", {}) if isinstance(tool_vex, dict) else {}
+    eval_cfg = tool_vex.get("eval", {}) if isinstance(tool_vex, dict) else {}
+    adapters: dict[str, str] = {}
+    if isinstance(eval_cfg, dict) and isinstance(eval_cfg.get("adapter"), str):
+        adapters["eval"] = eval_cfg["adapter"]
+    if isinstance(ai_cfg, dict):
+        for key in ("runtime", "framework", "template"):
+            value = ai_cfg.get(key)
+            if isinstance(value, str) and value:
+                adapters[key] = value
+
+    file_entries: list[dict[str, str]] = []
+    for rel in files:
+        abs_path = root / rel
+        if not abs_path.is_file():
+            continue
+        file_entries.append({
+            "path": rel.as_posix(),
+            "sha256": compute_sha256(abs_path),
+        })
+
+    locks: dict[str, str] = {}
+    lock_path = root / "uv.lock"
+    if lock_path.is_file():
+        locks["uv.lock"] = f"sha256:{compute_sha256(lock_path)}"
+
+    if created_at is None:
+        # Deterministic: use the newest mtime among included files so two
+        # consecutive exports over an unchanged tree produce byte-identical
+        # bytes. Callers (e.g. tests) can still pass an explicit override.
+        newest = 0.0
+        for rel in files:
+            abs_path = root / rel
+            try:
+                newest = max(newest, abs_path.stat().st_mtime)
+            except OSError:
+                continue
+        created_at = (
+            _dt.datetime.fromtimestamp(int(newest), tz=_dt.timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    manifest: dict[str, Any] = {
+        "schema": VEX_ARTIFACT_SCHEMA,
+        "name": name,
+        "version": version,
+        "created_at": created_at,
+        "python_requires": python_requires,
+        "entry_module": _derive_entry_module(name),
+        "policy": dict(policy),
+        "adapters": adapters,
+        "files": file_entries,
+        "models": [dict(m) for m in models],
+        "locks": locks,
+    }
+    return manifest
+
+
+def _deterministic_tarinfo(name: str, size: int, *, is_dir: bool) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name=name)
+    info.size = size
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    if is_dir:
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+    else:
+        info.type = tarfile.REGTYPE
+        info.mode = 0o644
+    return info
+
+
+def write_vex_artifact(
+    out_path: Path,
+    root: Path,
+    manifest: dict[str, Any],
+    files: Sequence[Path],
+) -> None:
+    """Write a deterministic `.vex` tarball to `out_path`."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+    raw = io.BytesIO()
+    with gzip.GzipFile(fileobj=raw, mode="wb", mtime=0, compresslevel=6) as gz:
+        with tarfile.open(fileobj=gz, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+            # Manifest first so `vex import` can short-circuit.
+            info = _deterministic_tarinfo(VEX_ARTIFACT_MANIFEST_NAME, len(manifest_bytes), is_dir=False)
+            tf.addfile(info, io.BytesIO(manifest_bytes))
+
+            for rel in sorted({Path(f["path"]) for f in manifest["files"]}, key=lambda p: p.as_posix()):
+                abs_path = root / rel
+                if not abs_path.is_file():
+                    continue
+                data = abs_path.read_bytes()
+                info = _deterministic_tarinfo(rel.as_posix(), len(data), is_dir=False)
+                tf.addfile(info, io.BytesIO(data))
+
+    out_path.write_bytes(raw.getvalue())
+
+
+def _default_export_out_path(root: Path, manifest: dict[str, Any]) -> Path:
+    name = manifest.get("name") or root.name or "agent"
+    version = manifest.get("version") or "0.0.0"
+    return root / "dist" / f"{name}-{version}.vex"
+
+
+def handle_export(args: argparse.Namespace) -> int:
+    root = project_root()
+    include_models: bool = getattr(args, "include_models", True)
+    include_venv: bool = getattr(args, "include_venv", False)
+    dry_run: bool = bool(getattr(args, "dry_run", False))
+    excludes = tuple(getattr(args, "exclude", []) or [])
+
+    files = collect_export_files(root, include_venv=include_venv, extra_excludes=excludes)
+    models = collect_export_model_manifests(root) if include_models else []
+
+    # `dist/` is in the default exclude list so the walk skips it, but model
+    # artifacts live under `dist/<name>/` and must travel with the bundle.
+    # Re-add them explicitly (manifest + referenced model file).
+    if models:
+        known = {p.as_posix() for p in files}
+        extras: list[Path] = []
+        for entry in models:
+            model_rel = entry.get("path")
+            if isinstance(model_rel, str):
+                model_path = root / model_rel
+                if model_path.is_file() and model_rel not in known:
+                    extras.append(Path(model_rel))
+                    known.add(model_rel)
+        # Also include every dist/<name>/vex-model.json we found.
+        for manifest_path in sorted((root / "dist").glob("*/vex-model.json")):
+            rel = manifest_path.relative_to(root).as_posix()
+            if rel not in known:
+                extras.append(Path(rel))
+                known.add(rel)
+        if extras:
+            files = sorted(list(files) + extras, key=lambda p: p.as_posix())
+
+    policy = load_vex_policy(root)
+    manifest = build_vex_artifact_manifest(root, policy, files, models)
+
+    if dry_run:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+        return 0
+
+    out_raw = getattr(args, "out", None)
+    out_path = (root / out_raw) if out_raw else _default_export_out_path(root, manifest)
+
+    write_vex_artifact(out_path, root, manifest, files)
+    rel = out_path.relative_to(root) if out_path.is_relative_to(root) else out_path
+    print(
+        f"Wrote {manifest['name']} v{manifest['version']} to {rel} "
+        f"({len(manifest['files'])} files, {len(manifest['models'])} models)"
+    )
+    return 0
+
+
+def _verify_manifest_shape(manifest: Any) -> tuple[bool, str]:
+    if not isinstance(manifest, dict):
+        return False, "manifest.json is not a JSON object"
+    if manifest.get("schema") != VEX_ARTIFACT_SCHEMA:
+        return False, f"unsupported artifact schema: {manifest.get('schema')!r}"
+    if not isinstance(manifest.get("files"), list):
+        return False, "manifest.files is not a list"
+    return True, ""
+
+
+def _destination_is_empty(dest: Path) -> bool:
+    if not dest.exists():
+        return True
+    if not dest.is_dir():
+        return False
+    try:
+        return not any(dest.iterdir())
+    except OSError:
+        return False
+
+
+def handle_import(args: argparse.Namespace) -> int:
+    artifact_raw = getattr(args, "artifact", None)
+    if not artifact_raw:
+        print("vex import requires an artifact path")
+        return 2
+    artifact_path = Path(artifact_raw)
+    if not artifact_path.is_absolute():
+        artifact_path = Path.cwd() / artifact_path
+    if not artifact_path.is_file():
+        print(f"artifact not found: {artifact_raw}")
+        return 2
+
+    dest_raw = getattr(args, "dest", None)
+    force: bool = bool(getattr(args, "force", False))
+
+    try:
+        tf = tarfile.open(artifact_path, mode="r:gz")
+    except (tarfile.TarError, OSError) as exc:
+        print(f"failed to open artifact: {exc}")
+        return 2
+
+    with tf:
+        try:
+            manifest_member = tf.getmember(VEX_ARTIFACT_MANIFEST_NAME)
+        except KeyError:
+            print("artifact is missing manifest.json")
+            return 2
+        manifest_fp = tf.extractfile(manifest_member)
+        if manifest_fp is None:
+            print("artifact manifest.json is not readable")
+            return 2
+        try:
+            manifest = json.loads(manifest_fp.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            print(f"manifest.json is not valid JSON: {exc}")
+            return 2
+
+        ok, message = _verify_manifest_shape(manifest)
+        if not ok:
+            print(message)
+            return 2
+
+        if dest_raw:
+            dest = Path(dest_raw)
+            if not dest.is_absolute():
+                dest = Path.cwd() / dest
+        else:
+            dest = Path.cwd() / artifact_path.stem
+
+        if not _destination_is_empty(dest) and not force:
+            print(f"refusing to overwrite non-empty destination: {dest}")
+            return 2
+
+        dest.mkdir(parents=True, exist_ok=True)
+
+        file_entries = manifest["files"]
+        sha_mismatches: list[tuple[str, str, str]] = []
+        for entry in file_entries:
+            if not isinstance(entry, dict):
+                continue
+            rel = entry.get("path")
+            expected_sha = entry.get("sha256")
+            if not isinstance(rel, str) or not isinstance(expected_sha, str):
+                continue
+            try:
+                member = tf.getmember(rel)
+            except KeyError:
+                msg = f"artifact is missing file listed in manifest: {rel}"
+                if force:
+                    print(f"WARN {msg} (--force)")
+                    continue
+                print(msg)
+                return 2
+            src = tf.extractfile(member)
+            if src is None:
+                print(f"could not read {rel} from artifact")
+                return 2
+            data = src.read()
+            actual_sha = hashlib.sha256(data).hexdigest()
+            if actual_sha != expected_sha:
+                sha_mismatches.append((rel, expected_sha, actual_sha))
+                if not force:
+                    print(
+                        f"sha mismatch for {rel}: expected {expected_sha}, got {actual_sha}"
+                    )
+                    return 2
+                print(
+                    f"WARN sha mismatch for {rel}: expected {expected_sha}, got {actual_sha} (--force)"
+                )
+            # Refuse any absolute or parent-traversal paths in the tar.
+            target = (dest / rel).resolve()
+            try:
+                target.relative_to(dest.resolve())
+            except ValueError:
+                print(f"refusing to extract path outside destination: {rel}")
+                return 2
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+
+        policy = manifest.get("policy", {}) if isinstance(manifest.get("policy"), dict) else {}
+        sandbox = bool(policy.get("sandbox", False))
+        network = str(policy.get("network", "unknown"))
+        entry_module = str(manifest.get("entry_module", "app.main"))
+        name = str(manifest.get("name", "agent"))
+        version = str(manifest.get("version", "0.0.0"))
+        try:
+            dest_display = dest.relative_to(Path.cwd())
+        except ValueError:
+            dest_display = dest
+        print(
+            f"Unpacked {name} v{version} to {dest_display}. "
+            f"policy.sandbox={str(sandbox).lower()} network={network} entry={entry_module}. "
+            f"Next: cd {dest_display} && vex doctor ai"
+        )
+        if sha_mismatches and force:
+            print(f"WARN {len(sha_mismatches)} file(s) had sha mismatches; imported with --force")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="vex",
@@ -3123,6 +3680,30 @@ def build_parser() -> argparse.ArgumentParser:
     schema_validate.set_defaults(handler=handle_schema)
 
     schema_parser.set_defaults(handler=handle_schema)
+
+    export_parser = subparsers.add_parser("export", help=COMMAND_HELP["export"])
+    export_parser.add_argument("--out", default=None)
+    export_parser.add_argument(
+        "--include-models",
+        dest="include_models",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    export_parser.add_argument(
+        "--include-venv",
+        dest="include_venv",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    export_parser.add_argument("--dry-run", dest="dry_run", action="store_true")
+    export_parser.add_argument("--exclude", action="append", default=[])
+    export_parser.set_defaults(handler=handle_export)
+
+    import_parser = subparsers.add_parser("import", help=COMMAND_HELP["import"])
+    import_parser.add_argument("artifact")
+    import_parser.add_argument("--dest", default=None)
+    import_parser.add_argument("--force", action="store_true")
+    import_parser.set_defaults(handler=handle_import)
 
     add_parser = subparsers.add_parser("add", help=COMMAND_HELP["add"])
     add_parser.add_argument("packages", nargs="+")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2851,5 +2851,399 @@ class CliTests(unittest.TestCase):
         )
 
 
+class VexExportImportTests(unittest.TestCase):
+    """Tests for `vex export` and `vex import` — portable .vex artifacts (#42)."""
+
+    def run_cli(self, argv: list[str]) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = main(argv)
+        return code, buffer.getvalue()
+
+    def _write_project(self, root: Path, name: str = "demo-bot", version: str = "0.1.0") -> None:
+        pyproject = (
+            "[project]\n"
+            f'name = "{name}"\n'
+            f'version = "{version}"\n'
+            'requires-python = ">=3.11"\n'
+            "\n"
+            "[tool.vex]\n"
+            "managed = true\n"
+            "\n"
+            "[tool.vex.policy]\n"
+            "sandbox = true\n"
+            'network = "deny"\n'
+            "\n"
+            "[tool.vex.ai]\n"
+            'template = "agent"\n'
+            'runtime = "vex-ai-runtime"\n'
+            'framework = "pydantic-ai"\n'
+            "\n"
+            "[tool.vex.eval]\n"
+            'adapter = "inspect"\n'
+        )
+        (root / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+        pkg_dir = root / "src" / name.replace("-", "_")
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / "__init__.py").write_text("\n", encoding="utf-8")
+        (pkg_dir / "main.py").write_text("def main():\n    print('hi')\n", encoding="utf-8")
+        (root / ".env.example").write_text("OPENAI_API_KEY=\n", encoding="utf-8")
+        (root / ".gitignore").write_text(".venv/\n__pycache__/\n", encoding="utf-8")
+        # Add noise that default excludes should strip.
+        venv = root / ".venv" / "bin"
+        venv.mkdir(parents=True, exist_ok=True)
+        (venv / "python").write_text("junk\n", encoding="utf-8")
+        cache = pkg_dir / "__pycache__"
+        cache.mkdir(parents=True, exist_ok=True)
+        (cache / "main.cpython-312.pyc").write_text("pyc\n", encoding="utf-8")
+        # Real secret that must never be exported.
+        (root / ".env").write_text("SECRET=42\n", encoding="utf-8")
+
+    def _extract_tar_members(self, artifact: Path) -> list[str]:
+        import tarfile as _tarfile
+        with _tarfile.open(artifact, mode="r:gz") as tf:
+            return sorted(m.name for m in tf.getmembers())
+
+    def test_export_writes_deterministic_tarball(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            os.chdir(temp_dir)
+            try:
+                code1, _ = self.run_cli(["export", "--out", "dist/a.vex"])
+                code2, _ = self.run_cli(["export", "--out", "dist/b.vex"])
+                a = (root / "dist" / "a.vex").read_bytes()
+                b = (root / "dist" / "b.vex").read_bytes()
+            finally:
+                os.chdir(original_cwd)
+        self.assertEqual(code1, 0)
+        self.assertEqual(code2, 0)
+        self.assertEqual(a, b, "two exports of the same tree must be byte-identical")
+
+    def test_export_manifest_has_required_fields(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root, name="support-bot", version="0.3.2")
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["export", "--dry-run"])
+            finally:
+                os.chdir(original_cwd)
+        self.assertEqual(code, 0)
+        manifest = json.loads(output)
+        for key in (
+            "schema",
+            "name",
+            "version",
+            "created_at",
+            "python_requires",
+            "entry_module",
+            "policy",
+            "adapters",
+            "files",
+            "models",
+            "locks",
+        ):
+            self.assertIn(key, manifest)
+        self.assertEqual(manifest["schema"], "vex-artifact/v1")
+        self.assertEqual(manifest["name"], "support-bot")
+        self.assertEqual(manifest["version"], "0.3.2")
+        self.assertEqual(manifest["entry_module"], "support_bot.main")
+        self.assertEqual(manifest["policy"]["network"], "deny")
+        self.assertEqual(manifest["adapters"]["eval"], "inspect")
+        self.assertEqual(manifest["adapters"]["framework"], "pydantic-ai")
+        self.assertEqual(manifest["adapters"]["runtime"], "vex-ai-runtime")
+
+    def test_export_excludes_venv_and_pycache_by_default(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["export", "--dry-run"])
+            finally:
+                os.chdir(original_cwd)
+        self.assertEqual(code, 0)
+        manifest = json.loads(output)
+        paths = [entry["path"] for entry in manifest["files"]]
+        for path in paths:
+            self.assertNotIn(".venv/", path)
+            self.assertNotIn("__pycache__", path)
+        # .env is excluded, .env.example is not.
+        self.assertNotIn(".env", paths)
+        self.assertIn(".env.example", paths)
+
+    def test_export_dry_run_writes_nothing_prints_manifest(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["export", "--dry-run", "--out", "dist/never.vex"])
+            finally:
+                os.chdir(original_cwd)
+            self.assertEqual(code, 0)
+            manifest = json.loads(output)
+            self.assertEqual(manifest["schema"], "vex-artifact/v1")
+            self.assertFalse((root / "dist" / "never.vex").exists())
+            self.assertFalse((root / "dist").exists())
+
+    def test_export_respects_custom_exclude_pattern(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            secrets = root / "src" / "demo_bot" / "secrets.py"
+            secrets.write_text("TOKEN='x'\n", encoding="utf-8")
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(
+                    ["export", "--dry-run", "--exclude", "src/demo_bot/secrets.py"]
+                )
+            finally:
+                os.chdir(original_cwd)
+        self.assertEqual(code, 0)
+        manifest = json.loads(output)
+        paths = [entry["path"] for entry in manifest["files"]]
+        self.assertNotIn("src/demo_bot/secrets.py", paths)
+        self.assertIn("src/demo_bot/main.py", paths)
+
+    def test_export_hashes_match_file_contents(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            os.chdir(temp_dir)
+            try:
+                code, output = self.run_cli(["export", "--dry-run"])
+            finally:
+                os.chdir(original_cwd)
+            self.assertEqual(code, 0)
+            manifest = json.loads(output)
+            import hashlib as _hashlib
+            for entry in manifest["files"]:
+                abs_path = root / entry["path"]
+                expected = _hashlib.sha256(abs_path.read_bytes()).hexdigest()
+                self.assertEqual(expected, entry["sha256"], f"hash mismatch for {entry['path']}")
+
+    def test_import_round_trip_preserves_tree(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            artifact = root / "dist" / "demo-bot-0.1.0.vex"
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli(["export"])
+                self.assertEqual(code, 0)
+                self.assertTrue(artifact.exists())
+            finally:
+                os.chdir(original_cwd)
+            # Unpack to an isolated directory.
+            with tempfile.TemporaryDirectory() as dest_dir:
+                dest = Path(dest_dir) / "unpacked"
+                os.chdir(dest_dir)
+                try:
+                    code, output = self.run_cli([
+                        "import",
+                        str(artifact),
+                        "--dest",
+                        str(dest),
+                    ])
+                finally:
+                    os.chdir(original_cwd)
+                self.assertEqual(code, 0)
+                self.assertIn("Unpacked demo-bot", output)
+                # Every non-excluded file from the source made it across,
+                # with identical content.
+                for rel in [
+                    "pyproject.toml",
+                    "src/demo_bot/__init__.py",
+                    "src/demo_bot/main.py",
+                    ".env.example",
+                    ".gitignore",
+                ]:
+                    self.assertTrue((dest / rel).exists(), f"missing {rel}")
+                    self.assertEqual(
+                        (root / rel).read_bytes(),
+                        (dest / rel).read_bytes(),
+                        f"content mismatch for {rel}",
+                    )
+                # .env was excluded on export and must not be in the unpack.
+                self.assertFalse((dest / ".env").exists())
+
+    def _tamper_file_in_artifact(self, artifact: Path, file_path: str, new_bytes: bytes) -> None:
+        """Rewrite one file in the .vex tar but leave manifest.json untouched."""
+        import tarfile as _tarfile
+        with _tarfile.open(artifact, mode="r:gz") as tf:
+            members = tf.getmembers()
+            blobs: dict[str, bytes] = {}
+            for m in members:
+                if m.isfile():
+                    fp = tf.extractfile(m)
+                    blobs[m.name] = fp.read() if fp else b""
+        blobs[file_path] = new_bytes
+        # Rewrite the tarball preserving deterministic layout.
+        import io as _io
+        import gzip as _gzip
+        raw = _io.BytesIO()
+        with _gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as gz:
+            with _tarfile.open(fileobj=gz, mode="w", format=_tarfile.USTAR_FORMAT) as out:
+                for name in sorted(blobs):
+                    data = blobs[name]
+                    info = _tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    info.mtime = 0
+                    info.mode = 0o644
+                    out.addfile(info, _io.BytesIO(data))
+        artifact.write_bytes(raw.getvalue())
+
+    def test_import_refuses_on_sha_mismatch(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            artifact = root / "dist" / "demo-bot-0.1.0.vex"
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli(["export"])
+                self.assertEqual(code, 0)
+            finally:
+                os.chdir(original_cwd)
+            self._tamper_file_in_artifact(artifact, "src/demo_bot/main.py", b"# tampered\n")
+            with tempfile.TemporaryDirectory() as dest_dir:
+                dest = Path(dest_dir) / "unpacked"
+                code, output = self.run_cli(["import", str(artifact), "--dest", str(dest)])
+            self.assertEqual(code, 2)
+            self.assertIn("sha mismatch", output)
+            self.assertIn("src/demo_bot/main.py", output)
+
+    def test_import_force_overrides_sha_mismatch_with_warning(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            artifact = root / "dist" / "demo-bot-0.1.0.vex"
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli(["export"])
+                self.assertEqual(code, 0)
+            finally:
+                os.chdir(original_cwd)
+            self._tamper_file_in_artifact(artifact, "src/demo_bot/main.py", b"# tampered\n")
+            with tempfile.TemporaryDirectory() as dest_dir:
+                dest = Path(dest_dir) / "unpacked"
+                code, output = self.run_cli([
+                    "import",
+                    str(artifact),
+                    "--dest",
+                    str(dest),
+                    "--force",
+                ])
+                self.assertEqual(code, 0)
+                self.assertIn("WARN sha mismatch", output)
+                self.assertEqual(
+                    (dest / "src/demo_bot/main.py").read_bytes(), b"# tampered\n"
+                )
+
+    def test_import_refuses_overwrite_of_non_empty_dest(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            artifact = root / "dist" / "demo-bot-0.1.0.vex"
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli(["export"])
+                self.assertEqual(code, 0)
+            finally:
+                os.chdir(original_cwd)
+            with tempfile.TemporaryDirectory() as dest_dir:
+                dest = Path(dest_dir) / "existing"
+                dest.mkdir()
+                (dest / "preexisting.txt").write_text("keep me\n", encoding="utf-8")
+                code, output = self.run_cli(["import", str(artifact), "--dest", str(dest)])
+                self.assertEqual(code, 2)
+                self.assertIn("refusing to overwrite", output)
+                self.assertTrue((dest / "preexisting.txt").exists())
+                # --force allows the overwrite.
+                code, _ = self.run_cli([
+                    "import",
+                    str(artifact),
+                    "--dest",
+                    str(dest),
+                    "--force",
+                ])
+                self.assertEqual(code, 0)
+                self.assertTrue((dest / "pyproject.toml").exists())
+
+    def test_export_includes_packaged_models_in_tarball(self) -> None:
+        """Model manifests under dist/ must travel with the artifact."""
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            # Simulate a `vex package-model` output tree.
+            (root / "dist" / "classifier" / "models").mkdir(parents=True)
+            (root / "dist" / "classifier" / "models" / "classifier.onnx").write_bytes(b"fakemodel")
+            import hashlib as _hashlib
+            sha = _hashlib.sha256(b"fakemodel").hexdigest()
+            (root / "dist" / "classifier" / "vex-model.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "vex-model/v1",
+                        "schema_version": "v1",
+                        "runtime": "vex-ai-runtime",
+                        "engine": "onnxruntime",
+                        "name": "classifier",
+                        "model_path": "models/classifier.onnx",
+                        "sha256": sha,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli(["export", "--out", "/tmp/_model-test.vex"])
+            finally:
+                os.chdir(original_cwd)
+            self.assertEqual(code, 0)
+            members = self._extract_tar_members(Path("/tmp/_model-test.vex"))
+            self.assertIn("dist/classifier/models/classifier.onnx", members)
+            self.assertIn("dist/classifier/vex-model.json", members)
+            # --no-include-models strips them back out.
+            os.chdir(temp_dir)
+            try:
+                code, _ = self.run_cli([
+                    "export",
+                    "--no-include-models",
+                    "--out",
+                    "/tmp/_nomodel-test.vex",
+                ])
+            finally:
+                os.chdir(original_cwd)
+            self.assertEqual(code, 0)
+            members = self._extract_tar_members(Path("/tmp/_nomodel-test.vex"))
+            self.assertNotIn("dist/classifier/models/classifier.onnx", members)
+
+    def test_build_vex_artifact_manifest_includes_uv_lock(self) -> None:
+        """build_vex_artifact_manifest should expose uv.lock hash when present."""
+        from vex.cli import build_vex_artifact_manifest, collect_export_files, load_vex_policy
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_project(root)
+            (root / "uv.lock").write_text("# lockfile\n", encoding="utf-8")
+            files = collect_export_files(root, include_venv=False)
+            policy = load_vex_policy(root)
+            manifest = build_vex_artifact_manifest(root, policy, files, [])
+        self.assertIn("uv.lock", manifest["locks"])
+        self.assertTrue(manifest["locks"]["uv.lock"].startswith("sha256:"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #42. Introduces two new top-level verbs that make the README's "portable execution contract" pitch literal: a vex-managed project now round-trips through a single `.vex` file that carries the policy snapshot, the scaffold source, `uv.lock`'s hash, and any `vex package-model` artifacts.

- `vex export [--out PATH] [--include-models] [--include-venv] [--dry-run] [--exclude GLOB]` — gzipped tarball under schema `vex-artifact/v1`.
- `vex import <artifact.vex> [--dest PATH] [--force]` — SHA-256 verified unpack with safe-dest refusal and a doctor-ready summary line.
- 12 new tests in `tests/test_cli.py`; full suite 98/98 green.
- New `docs/artifacts.md`; `docs/cli-reference.md` grew two new sections; `docs/policy.md` + `docs/deploy.md` cross-link.

## Manifest schema — `vex-artifact/v1`

```json
{
  "schema": "vex-artifact/v1",
  "name": "support-bot",
  "version": "0.3.2",
  "created_at": "2026-04-17T00:00:00Z",
  "python_requires": ">=3.11",
  "entry_module": "support_bot.main",
  "policy": { "sandbox": true, "network": "deny", ... },
  "adapters": {
    "eval": "inspect",
    "runtime": "vex-ai-runtime",
    "framework": "pydantic-ai",
    "template": "agent"
  },
  "files": [ { "path": "src/.../main.py", "sha256": "..." }, ... ],
  "models": [ { "path": "dist/.../model.onnx", "sha256": "...", "engine": "onnxruntime" } ],
  "locks": { "uv.lock": "sha256:..." }
}
```

## Determinism guarantee

Two exports of the same tree produce byte-identical `.vex` output. The writer:

- walks directories in sorted order;
- uses `USTAR_FORMAT` with `mtime = 0`, `uid = gid = 0`, `uname = gname = ""`, `0644` files / `0755` dirs;
- writes through `gzip.GzipFile(..., mtime=0)` so the gzip header carries no timestamp;
- seeds `manifest.created_at` from the newest included `mtime` rather than wall-clock `now()`.

Covered directly by `test_export_writes_deterministic_tarball`.

## Design decisions

- **No new dependencies.** The task called out `pathspec` as optional via `uvx`, but fetching a `uvx` child from inside a stdlib CLI during export adds a lot of moving parts for little gain over the obvious subset. Implemented a 40-line `_GitignoreMatcher` covering blank lines / comments, leading `!` negation, leading `/` anchoring, trailing `/` dir-only, and `fnmatch` on segments. Long-tail cases are covered by `--exclude`.
- **Model collection.** Respects the existing `vex package-model` output shape: walks `dist/<name>/vex-model.json`, reads `model_path` + `sha256`, and force-includes both the manifest and the model file in the tarball even though `dist/` is otherwise on the default exclude list. `--no-include-models` strips both sides.
- **`.env` vs `.env.example`.** `.env` is in the default excludes (secret material); `.env.example` is explicitly allowed (documented keys).
- **Safety.** `vex import` rejects tar entries that escape the destination via `..` / absolute paths. Non-empty dest requires `--force`. SHA-256 mismatch exits 2 unless `--force` downgrades it to a `WARN`.

## Out of scope (explicit follow-ups)

- `vex deploy <target> --from artifact.vex` — ship straight from a `.vex` without unpacking.
- `vex run --from artifact.vex --sandbox` — execute an artifact directly under the declared policy.
- Signing with a cosign key and a server-side verifier.
- Remote artifact registry / pull from URL.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — 98/98 green.
- [x] Dry-run on a toy project prints a `vex-artifact/v1` manifest with the right files/policy/adapters and does not write `dist/`.
- [x] Two consecutive `vex export` invocations over an unchanged tree produce byte-identical bytes (`shasum -a 256` match).
- [x] Round-trip: `vex export` → `vex import --dest fresh/` leaves a tree with matching contents for every non-excluded file; `.env` stays out, `.env.example` travels.
- [x] Tamper one file inside the tarball → `vex import` exits 2 with the expected/actual hashes; `--force` downgrades to `WARN` and extracts the tampered bytes.
- [x] `vex import` into a non-empty dir refuses (exit 2) unless `--force`.
- [x] `--include-models` bundles `dist/<name>/vex-model.json` + `model_path`; `--no-include-models` strips both.

Closes #42.