### PR TITLE
feat: vex dev trace tail + JSONL trace log (#43) (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ LangGraph CLI ships `langgraph new → langgraph dev → langgraph deploy`. Moda
 
 ```bash
 vex init agent support-bot   # scaffolds a PydanticAI agent under a default policy
-vex dev                      # watchfiles reload + provider banner + ollama fallback
+vex dev                      # watchfiles reload + provider banner + JSONL trace tail
 vex eval                     # PASS/FAIL over your dataset, CI-ready exit codes
 vex deploy modal             # ships it (preflight runs automatically)
 ```
@@ -100,7 +100,7 @@ Eval / deploy / doctor / init:
 - `vex doctor ai` — readiness report (uv, pyproject, policy, provider env, ollama reachability, eval dataset shape, deploy profile env vars)
 - `vex init agent <path> [--framework pydantic-ai|langgraph|claude-agent-sdk]` — scaffolds a real agent with `agent.py` (or `graph.py` for LangGraph) + one tool, `settings.py` with provider auto-resolution (openai / anthropic / ollama), `main.py` async entrypoint, `eval.py` with PASS/FAIL reporting, five seed eval cases, `prompts/system.md`, `.env.example`, `deploy.targets.toml` with `default` and `prod` profiles. Default framework: `pydantic-ai`
 - `vex init inference-api <path>` — FastAPI + uvicorn + typed schemas
-- `vex dev` — watchfiles reload + provider banner, with `--no-reload` / `--watch` / `--provider-check` flags
+- `vex dev` — watchfiles reload + provider banner + inline `[trace]` tail of an OTel-GenAI-shaped JSONL under `artifacts/traces/latest.jsonl` (see [`docs/tracing.md`](docs/tracing.md)), with `--no-reload` / `--watch` / `--provider-check` / `--no-trace` flags
 - `vex benchmark --command ... --runs ... --warmup ...` — harness with warmup control and JSON output
 - `vex package-model <model.onnx>` — versioned manifest with compatibility metadata:
   ```json
@@ -129,7 +129,6 @@ No API key? `vex` falls back to a local [`ollama`](https://ollama.com) model —
 
 The policy contract keeps getting sharper:
 
-- Trace tail in `vex dev` — inline LLM / tool-call trace view during the reload loop
 - Inspect AI adapter as the default eval backend (see [issue #23](https://github.com/peaktwilight/vex/issues/23))
 - Logfire + OTel GenAI observability hook on scaffolded agents (see [issue #24](https://github.com/peaktwilight/vex/issues/24))
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,6 +77,15 @@ Flags:
 - `--provider-check` / `--no-provider-check` — toggle the
   `[vex dev] provider=...` banner. Default: on. The banner warns when
   `provider=ollama` but `ollama` is not on PATH.
+- `--trace` / `--no-trace` — toggle the dev trace. Default: on. When on,
+  `vex dev` exports `VEX_TRACE_DIR=<root>/artifacts/traces` to the child
+  environment so the scaffolded agent's `enable_dev_tracing()` hook writes
+  one OTel-GenAI-shaped JSONL line per LLM / tool call to
+  `artifacts/traces/dev-<YYYYMMDD-HHMMSS>.jsonl`. A sibling
+  `artifacts/traces/latest.jsonl` symlink points at the current session so
+  `tail -f artifacts/traces/latest.jsonl` Just Works. When stderr is a TTY
+  `vex dev` also tails that file inline with a dim `[trace]` prefix. See
+  [`tracing.md`](tracing.md) for the schema and viewer tips.
 - trailing args — forwarded verbatim to the dev command.
 
 Exit codes:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,8 +26,10 @@ AI-native workflow (the actual product):
   (openai / anthropic / ollama auto-resolution), `eval.py`, seed dataset,
   `.env.example`, `deploy.targets.toml` with `default` and `prod` profiles
 - `vex init inference-api` — FastAPI + uvicorn scaffold with typed schemas
-- `vex dev` — watchfiles-based hot reload plus a provider banner that reports
-  which model backend (hosted or ollama fallback) will be used
+- `vex dev` — watchfiles-based hot reload, a provider banner that reports
+  which model backend (hosted or ollama fallback) will be used, and an
+  inline `[trace]` tail of an OTel-GenAI-shaped JSONL per dev session
+  (`artifacts/traces/latest.jsonl`; opt out with `--no-trace`)
 - `vex benchmark` — warmup-aware harness with JSON output
 - `vex eval` — dataset-driven checks with `--json`, `--min-pass-rate`, and a
   promptfoo adapter that auto-delegates when `promptfooconfig.yaml` is present
@@ -57,8 +59,6 @@ On the path to v1:
   a CI gate so evals fail closed on policy violations, not just quality regressions
 - `vex deploy --policy-gate` — block `--apply`/`--run` when policy preconditions
   (sandbox, secrets, model signature) are not met
-- Trace tail in `vex dev` — inline spans from the agent / HTTP loop during
-  hot-reload so developers see what the model actually did
 - Inspect AI adapter for `vex eval` — in flight in
   [issue #23](https://github.com/peaktwilight/vex/issues/23); becomes the new
   default once it lands

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,90 @@
+# Dev-mode tracing
+
+`vex dev` ships a minimal, stdlib-only trace logger so you can see LLM and tool
+calls flow past in real time without paying for a hosted observability product.
+The goal is first-five-minutes feedback — not a replacement for Logfire /
+Langfuse / Phoenix / Datadog.
+
+## What gets written
+
+When `vex dev` starts (and `--no-trace` is not passed), it:
+
+1. Creates `artifacts/traces/` under the project root.
+2. Exports `VEX_TRACE_DIR=<root>/artifacts/traces` to the child process env.
+3. Scaffolded agents read that env var and call
+   `vex.trace.enable_dev_tracing(dir)` in `main.py`.
+4. `enable_dev_tracing` opens `dev-<YYYYMMDD-HHMMSS>.jsonl` for append and
+   updates `latest.jsonl` to point at it (symlink on POSIX; plain pointer
+   file on platforms where symlinks are restricted).
+5. A background handler attached to the `pydantic_ai` logger translates each
+   structured log record into one JSONL line.
+
+If stderr is a TTY, `vex dev` also spawns a short tail thread that prints each
+new line back to stderr with a dim `[trace]` prefix so the reload loop and the
+trace share a single terminal.
+
+## Schema
+
+One JSON object per line. Fields:
+
+| field                             | required | notes                                               |
+| --------------------------------- | -------- | --------------------------------------------------- |
+| `ts`                              | yes      | UTC ISO 8601 timestamp                              |
+| `session_id`                      | yes      | UUID generated once per process                     |
+| `kind`                            | yes      | `"llm_call"` \| `"tool_call"` \| `"error"`          |
+| `latency_ms`                      | yes      | float                                               |
+| `gen_ai.system`                   | no       | `"openai"` \| `"anthropic"` \| `"ollama"` \| ...    |
+| `gen_ai.request.model`            | no       | model id the request asked for                      |
+| `gen_ai.response.model`           | no       | model id the provider actually served               |
+| `gen_ai.usage.input_tokens`       | no       | integer                                             |
+| `gen_ai.usage.output_tokens`      | no       | integer                                             |
+
+The `gen_ai.*` keys follow the
+[OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/),
+so any Langfuse / Phoenix / Datadog ingestor that speaks OTel-GenAI JSON can
+eat these logs with minimal glue.
+
+## Viewer tips
+
+The trace file is plain JSONL. Normal Unix tools work:
+
+```bash
+# Follow the current session.
+tail -f artifacts/traces/latest.jsonl
+
+# Pretty-print every row.
+tail -f artifacts/traces/latest.jsonl | jq '.'
+
+# Only LLM calls with their latency + model.
+jq -r 'select(.kind=="llm_call") | "\(.latency_ms)ms \(."gen_ai.request.model")"' \
+    artifacts/traces/dev-*.jsonl
+
+# Sum token usage across a session.
+jq -s 'map(."gen_ai.usage.input_tokens" // 0) | add' artifacts/traces/latest.jsonl
+```
+
+## Upgrading to a real backend
+
+The JSONL is deliberately minimal. When you're ready for a hosted backend,
+add the appropriate env var and the scaffolded `main.py` picks it up without
+further edits:
+
+- **Logfire** — set `LOGFIRE_TOKEN=pylf_v1_...`. The scaffolded
+  `main.py` already calls `logfire.configure()` + `logfire.instrument_pydantic_ai()`
+  when the token is present.
+- **Langfuse / Phoenix / Datadog** — point
+  `OTEL_EXPORTER_OTLP_ENDPOINT=https://...` and
+  `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ..."` at your collector.
+  The OTel SDK auto-config does the rest.
+
+The local JSONL stays on; it's additive, not exclusive.
+
+## Turning it off
+
+Pass `--no-trace` to `vex dev`:
+
+```bash
+vex dev --no-trace
+```
+
+That skips the `VEX_TRACE_DIR` export and the tail thread entirely.

--- a/src/vex/cli.py
+++ b/src/vex/cli.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import time
 import tomllib
 from pathlib import Path
@@ -959,6 +960,23 @@ def write_file(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def ensure_gitignore_entry(root: Path, entry: str) -> None:
+    """Append `entry` to `.gitignore` unless it's already there.
+
+    Creates `.gitignore` if it doesn't exist. Safe to call repeatedly.
+    """
+    path = root / ".gitignore"
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        lines = {line.strip() for line in existing.splitlines()}
+        if entry in lines or entry.rstrip("/") in lines:
+            return
+        suffix = "" if existing.endswith("\n") or not existing else "\n"
+        path.write_text(f"{existing}{suffix}{entry}\n", encoding="utf-8")
+        return
+    path.write_text(f"{entry}\n", encoding="utf-8")
+
+
 def scaffold_agent_template(root: Path, package_name: str) -> None:
     write_file(
         root / "src" / package_name / "__init__.py",
@@ -1050,6 +1068,12 @@ def scaffold_agent_template(root: Path, package_name: str) -> None:
             "        import logfire\n\n"
             "        logfire.configure()\n"
             "        logfire.instrument_pydantic_ai()\n"
+            "    except ImportError:\n"
+            "        pass\n\n"
+            "if os.environ.get(\"VEX_TRACE_DIR\"):\n"
+            "    try:\n"
+            "        from vex.trace import enable_dev_tracing\n\n"
+            "        enable_dev_tracing(os.environ[\"VEX_TRACE_DIR\"])\n"
             "    except ImportError:\n"
             "        pass\n\n"
             "from .agent import build_agent\n"
@@ -1203,6 +1227,7 @@ def scaffold_agent_template(root: Path, package_name: str) -> None:
             "    assert True\n"
         ),
     )
+    ensure_gitignore_entry(root, "artifacts/traces/")
 
 
 def _scaffold_agent_shared_files(root: Path, system_prompt: str) -> None:
@@ -4049,6 +4074,13 @@ def build_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=True,
     )
+    dev_parser.add_argument(
+        "--trace",
+        dest="trace",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="write an OTel-GenAI-shaped JSONL trace to artifacts/traces/ and tail it",
+    )
     dev_parser.add_argument("args", nargs=argparse.REMAINDER)
     dev_parser.set_defaults(handler=handle_dev)
 
@@ -4441,72 +4473,147 @@ def _try_import_watchfiles() -> Any:
     return watchfiles
 
 
+def _start_trace_tail_thread(trace_dir: Path) -> threading.Event:
+    """Spawn a daemon thread that tails `<trace_dir>/latest.jsonl` to stderr.
+
+    Each new line is printed with an ANSI-dim `[trace]` prefix. Returns a stop
+    Event so callers can signal shutdown. The thread is a daemon, so it also
+    dies with the process.
+
+    Only runs when stderr is a TTY — no escape-code noise in logs.
+    """
+    stop = threading.Event()
+    if not sys.stderr.isatty():
+        stop.set()
+        return stop
+
+    latest = trace_dir / "latest.jsonl"
+
+    def _tail() -> None:
+        # Wait for the first session to create `latest.jsonl`.
+        deadline = time.monotonic() + 30
+        while not latest.exists() and not stop.is_set():
+            if time.monotonic() > deadline:
+                return
+            time.sleep(0.25)
+        if stop.is_set():
+            return
+        try:
+            target = latest.resolve()
+            last_size = 0
+            current_inode = target.stat().st_ino if target.exists() else None
+            while not stop.is_set():
+                try:
+                    resolved = latest.resolve()
+                    stat = resolved.stat()
+                    # Session rotated: new symlink target.
+                    if current_inode is not None and stat.st_ino != current_inode:
+                        target = resolved
+                        current_inode = stat.st_ino
+                        last_size = 0
+                    if stat.st_size > last_size:
+                        with resolved.open("r", encoding="utf-8", errors="replace") as fh:
+                            fh.seek(last_size)
+                            for line in fh:
+                                line = line.rstrip("\n")
+                                if not line:
+                                    continue
+                                sys.stderr.write(f"\x1b[2m[trace]\x1b[0m {line}\n")
+                            sys.stderr.flush()
+                        last_size = stat.st_size
+                    elif stat.st_size < last_size:
+                        # File truncated or replaced.
+                        last_size = stat.st_size
+                except (FileNotFoundError, OSError):
+                    pass
+                stop.wait(0.25)
+        except Exception:
+            # Never let the tail thread take down the dev loop.
+            return
+
+    thread = threading.Thread(target=_tail, name="vex-trace-tail", daemon=True)
+    thread.start()
+    return stop
+
+
 def run_dev_with_reload(
     uv_args: list[str],
     watch_paths: Sequence[Path],
     watchfiles_module: Any = None,
+    trace_dir: Path | None = None,
 ) -> int:
     """Start the dev command and restart it whenever a watched path changes.
 
     Graceful shutdown: SIGTERM, wait up to 3s, then SIGKILL.
     """
-    if watchfiles_module is None:
-        watchfiles_module = _try_import_watchfiles()
-    if watchfiles_module is None:
-        print(
-            "[vex dev] 'watchfiles' is not installed — running without reload "
-            "(install with: uv add watchfiles)"
-        )
-        return run_uv(uv_args)
-
-    uv = uv_bin()
-    if uv is None:
-        print("vex requires 'uv' on PATH", file=sys.stderr)
-        return 127
-
-    if not watch_paths:
-        print("[vex dev] no watch paths found — running without reload")
-        return run_uv(uv_args)
-
-    argv = [uv, *uv_args]
-    str_paths = [str(p) for p in watch_paths]
-    print(f"[vex dev] watching {len(str_paths)} path(s) for changes")
-
-    def _spawn() -> subprocess.Popen[bytes]:
-        return subprocess.Popen(argv)
-
-    def _shutdown(proc: subprocess.Popen[bytes]) -> None:
-        if proc.poll() is not None:
-            return
+    tail_stop: threading.Event | None = None
+    if trace_dir is not None:
         try:
-            proc.terminate()
-        except ProcessLookupError:
-            return
-        try:
-            proc.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            try:
-                proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                pass
+            tail_stop = _start_trace_tail_thread(trace_dir)
+        except Exception:
+            tail_stop = None
 
-    proc = _spawn()
     try:
-        for _changes in watchfiles_module.watch(*str_paths):
-            print("[vex dev] change detected — restarting")
-            _shutdown(proc)
-            proc = _spawn()
-    except KeyboardInterrupt:
-        _shutdown(proc)
-        return 130
-    finally:
-        _shutdown(proc)
+        if watchfiles_module is None:
+            watchfiles_module = _try_import_watchfiles()
+        if watchfiles_module is None:
+            print(
+                "[vex dev] 'watchfiles' is not installed — running without reload "
+                "(install with: uv add watchfiles)"
+            )
+            return run_uv(uv_args)
 
-    return proc.returncode if proc.returncode is not None else 0
+        uv = uv_bin()
+        if uv is None:
+            print("vex requires 'uv' on PATH", file=sys.stderr)
+            return 127
+
+        if not watch_paths:
+            print("[vex dev] no watch paths found — running without reload")
+            return run_uv(uv_args)
+
+        argv = [uv, *uv_args]
+        str_paths = [str(p) for p in watch_paths]
+        print(f"[vex dev] watching {len(str_paths)} path(s) for changes")
+
+        def _spawn() -> subprocess.Popen[bytes]:
+            return subprocess.Popen(argv)
+
+        def _shutdown(proc: subprocess.Popen[bytes]) -> None:
+            if proc.poll() is not None:
+                return
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                return
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    pass
+
+        proc = _spawn()
+        try:
+            for _changes in watchfiles_module.watch(*str_paths):
+                print("[vex dev] change detected — restarting")
+                _shutdown(proc)
+                proc = _spawn()
+        except KeyboardInterrupt:
+            _shutdown(proc)
+            return 130
+        finally:
+            _shutdown(proc)
+
+        return proc.returncode if proc.returncode is not None else 0
+    finally:
+        if tail_stop is not None:
+            tail_stop.set()
 
 
 def handle_dev(args: argparse.Namespace) -> int:
@@ -4521,12 +4628,26 @@ def handle_dev(args: argparse.Namespace) -> int:
         print("vex dev requires [tool.vex.scripts].dev in pyproject.toml")
         return 2
 
+    trace_enabled = bool(getattr(args, "trace", True))
+    trace_dir: Path | None = None
+    if trace_enabled:
+        trace_dir = root / "artifacts" / "traces"
+        try:
+            trace_dir.mkdir(parents=True, exist_ok=True)
+            os.environ["VEX_TRACE_DIR"] = str(trace_dir)
+            print(f"[vex dev] trace dir={trace_dir} (tail with: tail -f {trace_dir / 'latest.jsonl'})")
+        except OSError:
+            trace_dir = None
+            os.environ.pop("VEX_TRACE_DIR", None)
+    else:
+        os.environ.pop("VEX_TRACE_DIR", None)
+
     if getattr(args, "no_reload", False):
         return run_uv(uv_args)
 
     extra_watch = list(getattr(args, "watch", []) or [])
     watch_paths = resolve_dev_watch_paths(extra_watch, root)
-    return run_dev_with_reload(uv_args, watch_paths)
+    return run_dev_with_reload(uv_args, watch_paths, trace_dir=trace_dir)
 
 
 def handle_benchmark(args: argparse.Namespace) -> int:
@@ -5048,6 +5169,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--no-reload",
                 "--provider-check",
                 "--no-provider-check",
+                "--trace",
+                "--no-trace",
             }
             while index < len(raw_argv):
                 token = raw_argv[index]

--- a/src/vex/trace.py
+++ b/src/vex/trace.py
@@ -1,0 +1,306 @@
+"""Dev-mode JSONL trace writer for `vex dev`.
+
+Minimal, stdlib-only OTel-GenAI-shaped JSONL logger. Activated by the
+`VEX_TRACE_DIR` env var so scaffolded agents stay zero-dep and only emit traces
+during `vex dev`.
+
+Schema (one JSON object per line):
+
+    {
+      "ts": "2026-04-17T12:00:00.000000+00:00",
+      "session_id": "9d1f...",
+      "kind": "llm_call" | "tool_call" | "error",
+      "latency_ms": 123.4,
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o-mini",
+      "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+      "gen_ai.usage.input_tokens": 42,
+      "gen_ai.usage.output_tokens": 17
+    }
+
+Any failure — import errors, filesystem errors, logging framework quirks — is
+swallowed. Tracing is strictly best-effort; it must never bring the agent down.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+__all__ = [
+    "enable_dev_tracing",
+    "record_llm_call",
+    "record_tool_call",
+    "record_error",
+]
+
+
+_SESSION_ID: str | None = None
+_WRITER_LOCK = threading.Lock()
+_ACTIVE_WRITER: "_JsonlWriter | None" = None
+_PYDANTIC_AI_HANDLER: logging.Handler | None = None
+
+
+OTEL_GEN_AI_KEYS: tuple[str, ...] = (
+    "gen_ai.system",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _session_id() -> str:
+    global _SESSION_ID
+    if _SESSION_ID is None:
+        _SESSION_ID = uuid.uuid4().hex
+    return _SESSION_ID
+
+
+class _JsonlWriter:
+    """Append-only JSONL file writer with a sibling `latest.jsonl` pointer."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = threading.Lock()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Touch the file so `tail -f latest.jsonl` has something to read.
+        path.touch(exist_ok=True)
+
+    def write(self, record: dict[str, Any]) -> None:
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        with self._lock:
+            try:
+                with self.path.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+                    fh.flush()
+            except OSError:
+                # Never take down the agent because tracing failed.
+                pass
+
+
+def _update_latest_pointer(dir_path: Path, target: Path) -> None:
+    """Make `<dir>/latest.jsonl` point at `target`.
+
+    Uses a symlink on POSIX. Falls back to writing a one-line pointer file if
+    symlinks are unavailable (e.g. unprivileged Windows). Tail consumers that
+    can't follow symlinks will still see the current session file path.
+    """
+    latest = dir_path / "latest.jsonl"
+    try:
+        if latest.exists() or latest.is_symlink():
+            try:
+                latest.unlink()
+            except OSError:
+                pass
+        os.symlink(target.name, latest)
+        return
+    except (OSError, NotImplementedError, AttributeError):
+        pass
+    try:
+        # Fallback: best-effort copy of current (empty) file so `tail -f` has a
+        # path that exists. The tail thread in cli.py tails the resolved latest
+        # symlink/file anyway.
+        latest.write_text("", encoding="utf-8")
+    except OSError:
+        pass
+
+
+class _PydanticAiLogHandler(logging.Handler):
+    """Capture PydanticAI structured log records and emit trace rows.
+
+    PydanticAI log records carry LLM/tool call metadata in their `extra` dict.
+    We translate whatever fields we recognize onto the OTel GenAI envelope.
+    Unknown events are ignored.
+    """
+
+    def __init__(self, writer: _JsonlWriter) -> None:
+        super().__init__(level=logging.DEBUG)
+        self._writer = writer
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        try:
+            payload = _log_record_to_trace(record)
+            if payload is not None:
+                self._writer.write(payload)
+        except Exception:
+            # Must never raise from inside logging.
+            pass
+
+
+def _log_record_to_trace(record: logging.LogRecord) -> dict[str, Any] | None:
+    """Best-effort mapping from a pydantic_ai LogRecord to a trace row."""
+    event = getattr(record, "event", None) or record.name or ""
+    event = str(event).lower()
+
+    kind: str | None = None
+    if record.levelno >= logging.ERROR:
+        kind = "error"
+    elif "tool" in event:
+        kind = "tool_call"
+    elif "llm" in event or "model" in event or "request" in event:
+        kind = "llm_call"
+    if kind is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "ts": _utc_now_iso(),
+        "session_id": _session_id(),
+        "kind": kind,
+        "latency_ms": float(getattr(record, "latency_ms", 0.0) or 0.0),
+    }
+
+    for key in OTEL_GEN_AI_KEYS:
+        attr = key.replace(".", "_")
+        value = getattr(record, attr, None)
+        if value is None:
+            value = record.__dict__.get(key)
+        if value is not None:
+            payload[key] = value
+
+    message = record.getMessage()
+    if message and kind == "error":
+        payload["error.message"] = message
+
+    return payload
+
+
+def _build_payload(
+    kind: str,
+    latency_ms: float,
+    fields: dict[str, Any] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ts": _utc_now_iso(),
+        "session_id": _session_id(),
+        "kind": kind,
+        "latency_ms": float(latency_ms),
+    }
+    if fields:
+        for key, value in fields.items():
+            if value is None:
+                continue
+            payload[key] = value
+    return payload
+
+
+def record_llm_call(latency_ms: float, **fields: Any) -> None:
+    """Record an LLM call row into the active trace writer.
+
+    No-op if `enable_dev_tracing` was never called (or failed).
+    """
+    writer = _ACTIVE_WRITER
+    if writer is None:
+        return
+    try:
+        writer.write(_build_payload("llm_call", latency_ms, fields))
+    except Exception:
+        pass
+
+
+def record_tool_call(latency_ms: float, **fields: Any) -> None:
+    """Record a tool call row."""
+    writer = _ACTIVE_WRITER
+    if writer is None:
+        return
+    try:
+        writer.write(_build_payload("tool_call", latency_ms, fields))
+    except Exception:
+        pass
+
+
+def record_error(latency_ms: float, **fields: Any) -> None:
+    """Record an error row."""
+    writer = _ACTIVE_WRITER
+    if writer is None:
+        return
+    try:
+        writer.write(_build_payload("error", latency_ms, fields))
+    except Exception:
+        pass
+
+
+def enable_dev_tracing(dir: str | os.PathLike[str]) -> Path | None:
+    """Start JSONL trace writing at `<dir>/dev-<YYYYMMDD-HHMMSS>.jsonl`.
+
+    Also updates `<dir>/latest.jsonl` to point at the new file. Returns the
+    path of the new trace file, or None if setup failed.
+
+    Tracing is intentionally best-effort:
+      - import failures inside this function are swallowed
+      - filesystem errors are swallowed
+      - any exception raised during set-up results in a silent no-op
+    """
+    global _ACTIVE_WRITER, _PYDANTIC_AI_HANDLER
+
+    try:
+        dir_path = Path(dir)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        trace_path = dir_path / f"dev-{stamp}.jsonl"
+        # Guarantee a unique filename if two sessions start in the same second.
+        counter = 0
+        while trace_path.exists():
+            counter += 1
+            trace_path = dir_path / f"dev-{stamp}-{counter}.jsonl"
+
+        writer = _JsonlWriter(trace_path)
+        with _WRITER_LOCK:
+            _ACTIVE_WRITER = writer
+        _update_latest_pointer(dir_path, trace_path)
+
+        # Attach a logger handler to pydantic_ai so structured LLM / tool call
+        # log records turn into trace rows. If logfire is present, it usually
+        # grabs the same records via its own instrumentation — that's fine,
+        # the handler here remains a no-cost fallback.
+        try:
+            logger = logging.getLogger("pydantic_ai")
+            handler = _PydanticAiLogHandler(writer)
+            # Detach any previous handler from a prior enable call.
+            if _PYDANTIC_AI_HANDLER is not None:
+                try:
+                    logger.removeHandler(_PYDANTIC_AI_HANDLER)
+                except Exception:
+                    pass
+            logger.addHandler(handler)
+            # Don't lower the user's configured level; just make sure ours sees
+            # records when they propagate here.
+            if logger.level == logging.NOTSET:
+                logger.setLevel(logging.INFO)
+            _PYDANTIC_AI_HANDLER = handler
+        except Exception:
+            pass
+
+        return trace_path
+    except Exception:
+        return None
+
+
+def _reset_for_tests() -> None:
+    """Test helper: forget the active writer + session id."""
+    global _ACTIVE_WRITER, _SESSION_ID, _PYDANTIC_AI_HANDLER
+    if _PYDANTIC_AI_HANDLER is not None:
+        try:
+            logging.getLogger("pydantic_ai").removeHandler(_PYDANTIC_AI_HANDLER)
+        except Exception:
+            pass
+    _ACTIVE_WRITER = None
+    _SESSION_ID = None
+    _PYDANTIC_AI_HANDLER = None
+
+
+# Keep an import-time side effect for visibility only when debugging.
+if os.environ.get("VEX_TRACE_DEBUG") == "1":  # pragma: no cover - diagnostic
+    print(f"[vex.trace] module loaded (pid={os.getpid()})", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import logging
 import os
 import tempfile
 import unittest
@@ -3443,6 +3444,198 @@ class VexExportImportTests(unittest.TestCase):
             manifest = build_vex_artifact_manifest(root, policy, files, [])
         self.assertIn("uv.lock", manifest["locks"])
         self.assertTrue(manifest["locks"]["uv.lock"].startswith("sha256:"))
+
+
+class DevTraceTests(unittest.TestCase):
+    """Coverage for vex dev --trace (closes #43)."""
+
+    def run_cli(self, argv: list[str]) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = main(argv)
+        return code, buffer.getvalue()
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_sets_vex_trace_dir_env_by_default(
+        self, _run_command: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _out = self.run_cli(["dev", "--no-reload"])
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(code, 0)
+            actual_value = os.environ.get("VEX_TRACE_DIR")
+            self.assertIsNotNone(actual_value)
+            assert actual_value is not None
+            expected = (Path(temp_dir) / "artifacts" / "traces").resolve()
+            self.assertEqual(Path(actual_value).resolve(), expected)
+            self.assertTrue((Path(temp_dir) / "artifacts" / "traces").is_dir())
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("vex.cli.uv_bin", return_value="uv")
+    @patch("vex.cli.run_command", return_value=0)
+    def test_dev_no_trace_flag_disables_env(
+        self, _run_command: object, _uv_bin: object
+    ) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pyproject = Path(temp_dir) / "pyproject.toml"
+            pyproject.write_text(
+                "[tool.vex.scripts]\n"
+                'dev = "python -m http.server"\n',
+                encoding="utf-8",
+            )
+            os.chdir(temp_dir)
+            try:
+                code, _out = self.run_cli(["dev", "--no-reload", "--no-trace"])
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(code, 0)
+            self.assertNotIn("VEX_TRACE_DIR", os.environ)
+            self.assertFalse((Path(temp_dir) / "artifacts" / "traces").exists())
+
+    def test_trace_module_writes_jsonl_per_llm_call(self) -> None:
+        from vex import trace as trace_mod
+
+        trace_mod._reset_for_tests()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = trace_mod.enable_dev_tracing(temp_dir)
+            self.assertIsNotNone(path)
+            try:
+                logger = logging.getLogger("pydantic_ai")
+                record = logger.makeRecord(
+                    "pydantic_ai",
+                    logging.INFO,
+                    "test",
+                    0,
+                    "llm request complete",
+                    (),
+                    None,
+                    extra={
+                        "event": "llm_request",
+                        "latency_ms": 42.0,
+                        "gen_ai.system": "openai",
+                        "gen_ai.request.model": "gpt-4o-mini",
+                        "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                        "gen_ai.usage.input_tokens": 7,
+                        "gen_ai.usage.output_tokens": 3,
+                    },
+                )
+                # Fire through our handler directly so we don't depend on
+                # global logger propagation being enabled.
+                handler = trace_mod._PYDANTIC_AI_HANDLER
+                self.assertIsNotNone(handler)
+                handler.handle(record)  # type: ignore[union-attr]
+
+                assert path is not None
+                lines = [
+                    line for line in path.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+                self.assertEqual(len(lines), 1)
+                payload = json.loads(lines[0])
+                self.assertEqual(payload["kind"], "llm_call")
+                self.assertIn("ts", payload)
+                self.assertIn("session_id", payload)
+                self.assertEqual(payload["latency_ms"], 42.0)
+            finally:
+                trace_mod._reset_for_tests()
+
+    def test_trace_otel_envelope_fields_present(self) -> None:
+        from vex import trace as trace_mod
+
+        trace_mod._reset_for_tests()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = trace_mod.enable_dev_tracing(temp_dir)
+            self.assertIsNotNone(path)
+            try:
+                trace_mod.record_llm_call(
+                    latency_ms=128.5,
+                    **{
+                        "gen_ai.system": "anthropic",
+                        "gen_ai.request.model": "claude-3-5-sonnet-latest",
+                        "gen_ai.response.model": "claude-3-5-sonnet-20241022",
+                        "gen_ai.usage.input_tokens": 12,
+                        "gen_ai.usage.output_tokens": 9,
+                    },
+                )
+                assert path is not None
+                lines = [
+                    line for line in path.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+                self.assertEqual(len(lines), 1)
+                payload = json.loads(lines[0])
+                for key in trace_mod.OTEL_GEN_AI_KEYS:
+                    self.assertIn(key, payload, msg=f"missing otel key: {key}")
+                self.assertEqual(payload["gen_ai.system"], "anthropic")
+                self.assertEqual(payload["gen_ai.usage.input_tokens"], 12)
+                self.assertEqual(payload["latency_ms"], 128.5)
+                self.assertEqual(payload["kind"], "llm_call")
+            finally:
+                trace_mod._reset_for_tests()
+
+    def test_trace_module_updates_latest_symlink(self) -> None:
+        from vex import trace as trace_mod
+
+        trace_mod._reset_for_tests()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first = trace_mod.enable_dev_tracing(temp_dir)
+            trace_mod._reset_for_tests()
+            # Second session: must rotate `latest.jsonl` to the new file.
+            # Sleep briefly so the timestamp in the filename differs.
+            import time as _time
+            _time.sleep(1.1)
+            second = trace_mod.enable_dev_tracing(temp_dir)
+            try:
+                self.assertIsNotNone(first)
+                self.assertIsNotNone(second)
+                assert first is not None and second is not None
+                self.assertNotEqual(first, second)
+                latest = Path(temp_dir) / "latest.jsonl"
+                self.assertTrue(latest.exists() or latest.is_symlink())
+                # Resolve (follow symlink if any) and compare to second file.
+                resolved = latest.resolve()
+                self.assertEqual(resolved, second.resolve())
+            finally:
+                trace_mod._reset_for_tests()
+
+    def test_scaffold_main_py_includes_trace_hook(self) -> None:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            try:
+                code, _output = self.run_cli(["init", "agent", "support-agent"])
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(code, 0)
+            root = Path(temp_dir) / "support-agent"
+            main_src = (root / "src" / "support_agent" / "main.py").read_text(
+                encoding="utf-8"
+            )
+
+            self.assertIn('if os.environ.get("VEX_TRACE_DIR"):', main_src)
+            self.assertIn("from vex.trace import enable_dev_tracing", main_src)
+            self.assertIn("enable_dev_tracing(os.environ[\"VEX_TRACE_DIR\"])", main_src)
+            self.assertIn("except ImportError:", main_src)
+
+            gitignore = root / ".gitignore"
+            self.assertTrue(gitignore.exists())
+            self.assertIn("artifacts/traces/", gitignore.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Ships the deferred trace-tail piece of `vex dev`. Answers the three #8
deferral questions (write location, schema, emit layer) and wires the whole
loop end-to-end.

- `vex dev` exports `VEX_TRACE_DIR=<root>/artifacts/traces` (opt out with
  `--no-trace`) and tails `artifacts/traces/latest.jsonl` inline with a dim
  `[trace]` prefix when stderr is a TTY.
- Scaffolded agent `main.py` gains a guarded hook beside the existing
  Logfire one:
  ```python
  if os.environ.get("VEX_TRACE_DIR"):
      try:
          from vex.trace import enable_dev_tracing
          enable_dev_tracing(os.environ["VEX_TRACE_DIR"])
      except ImportError:
          pass
  ```
- New `src/vex/trace.py`: `enable_dev_tracing(dir)` opens
  `dev-<YYYYMMDD-HHMMSS>.jsonl` for append, points a `latest.jsonl` symlink
  at it (plain pointer file fallback on platforms that reject symlinks),
  and attaches a `logging.getLogger("pydantic_ai")` handler that translates
  structured log records into OTel-GenAI-shaped rows. Public API:
  `record_llm_call` / `record_tool_call` / `record_error`.
- Scaffold now writes `artifacts/traces/` to `.gitignore`.

## Trace row schema

One JSON object per line. Required envelope: `ts`, `session_id`, `kind`
(`llm_call` / `tool_call` / `error`), `latency_ms`. Optional OTel GenAI
fields: `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`,
`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`.

Compatible with Langfuse / Phoenix / Datadog OTel ingestion.

## Design decisions

- **Logger vs logfire**: the default capture path uses
  `logging.getLogger("pydantic_ai")` + a custom handler so zero hard deps
  ride on the trace module. If `logfire` / OTel SDK is also configured it
  runs in parallel — both emit into their own sinks, no conflict.
- **Symlink on Windows**: `os.symlink` is attempted first; on any
  `OSError` / `NotImplementedError` we fall back to writing an empty
  `latest.jsonl` file. Unix workflow stays the expected `tail -f
  artifacts/traces/latest.jsonl`; Windows users get pointed at the
  timestamped file directly.
- **Defensive tracing**: every entry point in `vex.trace` swallows
  exceptions so a broken trace never takes down the agent.

## Framework-template compatibility (re: #45)

The hook is framework-agnostic — just an env-var check and a try-import.
Today `scaffold_agent_template` is the only function emitting `main.py`.
When #45 introduces `scaffold_langgraph_template` / `scaffold_claude_sdk_template`,
the snippet should be copied into each new template verbatim.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest tests.test_cli` — 93 tests, all green
- [x] `test_dev_sets_vex_trace_dir_env_by_default`
- [x] `test_dev_no_trace_flag_disables_env`
- [x] `test_trace_module_writes_jsonl_per_llm_call`
- [x] `test_trace_otel_envelope_fields_present`
- [x] `test_trace_module_updates_latest_symlink`
- [x] `test_scaffold_main_py_includes_trace_hook`

## Out of scope

- Real TUI pane (kept a simple stderr tail)
- Replay from JSONL
- OpenTelemetry SDK as a hard dep

Closes #43.
Closes #8.